### PR TITLE
Dev/noarg runner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     # isn't covered by this document) at the time of writing.
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python27-x64"

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from os.path import join
+from xdoctest import utils
+
+
+def test_zero_args():
+    from xdoctest import runner
+
+    source = utils.codeblock(
+        '''
+        # --- HELPERS ---
+        def zero_args1(a=1):
+            pass
+
+
+        def zero_args2(*args):
+            pass
+
+
+        def zero_args3(**kwargs):
+            pass
+
+
+        def zero_args4(a=1, b=2, *args, **kwargs):
+            pass
+
+
+        def non_zero_args1(a):
+            pass
+
+
+        def non_zero_args2(a, b):
+            pass
+
+
+        def non_zero_args3(a, b, *args):
+            pass
+
+
+        def non_zero_args4(a, b, **kwargs):
+            pass
+
+
+        def non_zero_args5(a, b=1, **kwargs):
+            pass
+        ''')
+
+    with utils.TempDir() as temp:
+        dpath = temp.dpath
+        modpath = join(dpath, 'test_zero.py')
+
+        with open(modpath, 'w') as file:
+            file.write(source)
+
+        zero_func_names = {
+            example.callname
+            for example in runner._gather_zero_arg_examples(modpath)
+        }
+        assert zero_func_names == set(['zero_args1', 'zero_args2',
+                                       'zero_args3', 'zero_args4'])
+
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        pytest testing/test_runner.py -s
+        python testing/test_runner.py test_zero_args
+    """
+    import pytest
+    pytest.main([__file__])
+    # import xdoctest
+    # xdoctest.doctest_module(__file__)

--- a/xdoctest/core.py
+++ b/xdoctest/core.py
@@ -64,7 +64,7 @@ class DocTest(object):
     """
 
     def __init__(self, docsrc, modpath=None, callname=None, num=0,
-                 lineno=1, fpath=None, block_type=None):
+                 lineno=1, fpath=None, block_type=None, mode='pytest'):
 
         # if we know the google block type it is recorded
         self.block_type = block_type
@@ -97,6 +97,8 @@ class DocTest(object):
         self.evaled_results = []
         self.module = None
         self.globs = {}
+        # Hint at what is running this doctest
+        self.mode = mode
 
     def __nice__(self):
         parts = []
@@ -414,12 +416,12 @@ class DocTest(object):
 
     @property
     def cmdline(self):
-        # TODO: move to pytest
-        return 'pytest ' + self.node
-
-    @property
-    def native_cmdline(self):
-        return 'python -m ' + self.modname + ' ' + self.unique_callname
+        if self.mode == 'pytest':
+            return 'pytest ' + self.node
+        elif self.mode == 'native':
+            return 'python -m ' + self.modname + ' ' + self.unique_callname
+        else:
+            raise KeyError(self.mode)
 
     def pre_run(self, verbose):
         if verbose >= 1:

--- a/xdoctest/core.py
+++ b/xdoctest/core.py
@@ -344,8 +344,6 @@ class DocTest(object):
                 code = compile(
                     part.source, mode=mode,
                     filename='<doctest:' + self.node + '>',
-                    # filename='<doctest>',
-                    # self.node,
                     flags=compileflags, dont_inherit=True
                 )
             except KeyboardInterrupt:  # nocover

--- a/xdoctest/core.py
+++ b/xdoctest/core.py
@@ -428,7 +428,11 @@ class DocTest(object):
                     print(utils.color_text('============', 'white'))
                 else:
                     print('============')
-            print('* BEGIN DOCTEST : {}'.format(self.node))
+            if self.block_type == 'zero-arg':
+                # zero-arg funcs arent doctests, but we can still run them
+                print('* ZERO-ARG FUNC : {}'.format(self.node))
+            else:
+                print('* BEGIN DOCTEST : {}'.format(self.node))
             if verbose >= 3:
                 print(self.format_src())
 

--- a/xdoctest/core.py
+++ b/xdoctest/core.py
@@ -431,12 +431,8 @@ class DocTest(object):
                 else:
                     print('============')
             print('* BEGIN DOCTEST : {}'.format(self.node))
-            # print(self.cmdline)
             if verbose >= 3:
                 print(self.format_src())
-        # else:  # nocover
-        #     sys.stdout.write('.')
-        #     sys.stdout.flush()
 
     def failed_line_offset(self):
         if self.exc_info is None:

--- a/xdoctest/runner.py
+++ b/xdoctest/runner.py
@@ -89,7 +89,11 @@ def _zero_arg_runner(command, modpath, verbose):
                 example = core.DocTest(docsrc=docsrc, modpath=_modpath,
                                        callname=callname, block_type='no-arg')
                 if command in example.valid_testnames:
-                    example.run(verbose)
+                    try:
+                        example.run(verbose)
+                    except Exception:
+                        print('\n'.join(example.repr_failure()))
+                        raise
 
 
 def _run_examples(enabled_examples, verbose):

--- a/xdoctest/runner.py
+++ b/xdoctest/runner.py
@@ -30,17 +30,99 @@ def doctest_module(modpath_or_name=None, command=None, argv=None, exclude=[],
     """
     print('Start doctest_module({!r})'.format(modpath_or_name))
 
+    # Determine package name via caller if not specified
     if modpath_or_name is None:
-        # Determine package name via caller if not specified
         frame_parent = dynamic.get_parent_frame()
         modpath = frame_parent.f_globals['__file__']
     else:
         modpath = core._rectify_to_modpath(modpath_or_name)
 
+    command, style, verbose = _parse_commandline(command, style, verbose, argv)
+
+    if command == 'list':
+        print('Listing tests')
+
+    if command is None:
+        # Display help if command is not specified
+        print('Not testname given. Use `all` to run everything or')
+        print('Pick from a list of valid choices:')
+        command = 'list'
+
+    run_all = (command == 'all')
+
+    # Parse all valid examples
+    examples = list(core.parse_doctestables(modpath, exclude=exclude,
+                                            style=style))
+
+    if command == 'list':
+        if len(examples) == 0:
+            print('... no docstrings with examples found')
+        else:
+            print('\n'.join([example.native_cmdline for example in examples]))
+    else:
+        print('gathering tests')
+        enabled_examples = []
+        for example in examples:
+            if run_all or command in example.valid_testnames:
+                if run_all and example.is_disabled():
+                    continue
+                enabled_examples.append(example)
+
+        if len(enabled_examples) == 0:
+            # Check for arg-less funcs
+            print('no tests found, checking for zero-arg funcs')
+            _zero_arg_runner(command, modpath, verbose)
+        else:
+            _run_examples(enabled_examples, verbose)
+
+
+def _zero_arg_runner(command, modpath, verbose):
+    """
+    Run functions in `modpath` args that match `command` as long as they
+    take no args (so we can automatically make a dummy docstring).
+    """
+    for calldefs, _modpath in core.package_calldefs(modpath):
+        for callname, calldef in calldefs.items():
+            if calldef.argnames is not None and len(calldef.argnames) == 0:
+                # Create a dummy doctest example for a no-arg function
+                docsrc = '>>> {}()'.format(callname)
+                example = core.DocTest(docsrc=docsrc, modpath=_modpath,
+                                       callname=callname, block_type='no-arg')
+                if command in example.valid_testnames:
+                    example.run(verbose)
+
+
+def _run_examples(enabled_examples, verbose):
+    n_total = len(enabled_examples)
+    print('running %d test(s)' % n_total)
+    summaries = []
+    for example in enabled_examples:
+        try:
+            summary = example.run(verbose=verbose)
+            if not verbose:
+                sys.stdout.write('.')
+                sys.stdout.flush()
+        except Exception:
+            if not verbose:
+                sys.stdout.write('F')
+                sys.stdout.flush()
+            print('\n'.join(example.repr_failure()))
+            raise
+        summaries.append(summary)
+    if verbose <= 0:
+        print('')
+    n_passed = sum(s['passed'] for s in summaries)
+    print('Finished doctests')
+    print('%d / %d passed'  % (n_passed, n_total))
+
+    return n_passed == n_total
+
+
+def _parse_commandline(command, style, verbose, argv):
+    # Determine command via sys.argv if not specified
     if command is None:
         if argv is None:
             argv = sys.argv
-        # Determine command via sys.argv if not specified
         argv = argv[1:]
         if len(argv) >= 1:
             command = argv[0]
@@ -53,63 +135,15 @@ def doctest_module(modpath_or_name=None, command=None, argv=None, exclude=[],
     elif '--google' in sys.argv:
         style = 'google'
 
-    # Parse all valid examples
-    examples = list(core.parse_doctestables(modpath, exclude=exclude,
-                                            style=style))
-
+    # Parse verbosity flag
     if verbose is None:
         if '--verbose' in sys.argv:
             verbose = 3
         elif '--quiet' in sys.argv:
             verbose = 0
         else:
-            verbose = 3 if len(examples) == 1 else 2
-
-    if command == 'list':
-        print('Listing tests')
-
-    if command is None:
-        # Display help if command is not specified
-        print('Not testname given. Use `all` to run everything or')
-        print('Pick from a list of valid choices:')
-        command = 'list'
-
-    run_all = command == 'all'
-
-    if command == 'list':
-        print('\n'.join([example.native_cmdline for example in examples]))
-    else:
-        print('gathering tests')
-        enabled_examples = []
-        for example in examples:
-            if run_all or command in example.valid_testnames:
-                if run_all and example.is_disabled():
-                    continue
-                enabled_examples.append(example)
-
-        n_total = len(enabled_examples)
-        print('running %d test(s)' % (n_total))
-        summaries = []
-        for example in enabled_examples:
-            try:
-                summary = example.run(verbose=verbose)
-                if not verbose:
-                    sys.stdout.write('.')
-                    sys.stdout.flush()
-            except Exception:
-                if not verbose:
-                    sys.stdout.write('F')
-                    sys.stdout.flush()
-                print('\n'.join(example.repr_failure()))
-                raise
-            summaries.append(summary)
-        if verbose <= 0:
-            print('')
-        n_passed = sum(s['passed'] for s in summaries)
-        print('Finished doctests')
-        print('%d / %d passed'  % (n_passed, n_total))
-
-        return n_passed == n_total
+            verbose = 2
+    return command, style, verbose
 
 
 if __name__ == '__main__':

--- a/xdoctest/runner.py
+++ b/xdoctest/runner.py
@@ -73,12 +73,12 @@ def doctest_module(modpath_or_name=None, command=None, argv=None, exclude=[],
 
         if len(enabled_examples) == 0:
             # Check for arg-less funcs
-            enabled_examples += list(_zero_arg_examples(command, modpath))
+            enabled_examples += list(_gather_zero_arg_examples(command, modpath))
 
         _run_examples(enabled_examples, verbose)
 
 
-def _zero_arg_examples(command, modpath):
+def _gather_zero_arg_examples(command, modpath):
     """
     Find functions in `modpath` args that match `command` as long as they
     take no args (so we can automatically make a dummy docstring).
@@ -86,10 +86,10 @@ def _zero_arg_examples(command, modpath):
     for calldefs, _modpath in core.package_calldefs(modpath):
         for callname, calldef in calldefs.items():
             if calldef.argnames is not None and len(calldef.argnames) == 0:
-                # Create a dummy doctest example for a no-arg function
+                # Create a dummy doctest example for a zero-arg function
                 docsrc = '>>> {}()'.format(callname)
                 example = core.DocTest(docsrc=docsrc, modpath=_modpath,
-                                       callname=callname, block_type='no-arg')
+                                       callname=callname, block_type='zero-arg')
                 if command in example.valid_testnames:
                     example.mode = 'native'
                     yield example

--- a/xdoctest/runner.py
+++ b/xdoctest/runner.py
@@ -93,12 +93,12 @@ def _gather_zero_arg_examples(command, modpath):
                 if command in example.valid_testnames:
                     example.mode = 'native'
 
-                    if True:
-                        import importlib
-                        mod = importlib.import_module(example.modname)
-                        getattr(mod, callname)()
-                    else:
-                        yield example
+                    # if True:
+                    #     import importlib
+                    #     mod = importlib.import_module(example.modname)
+                    #     getattr(mod, callname)()
+                    # else:
+                    yield example
 
 
 def _run_examples(enabled_examples, verbose):

--- a/xdoctest/runner.py
+++ b/xdoctest/runner.py
@@ -92,7 +92,13 @@ def _gather_zero_arg_examples(command, modpath):
                                        callname=callname, block_type='zero-arg')
                 if command in example.valid_testnames:
                     example.mode = 'native'
-                    yield example
+
+                    if True:
+                        import importlib
+                        mod = importlib.import_module(example.modname)
+                        getattr(mod, callname)()
+                    else:
+                        yield example
 
 
 def _run_examples(enabled_examples, verbose):

--- a/xdoctest/static_analysis.py
+++ b/xdoctest/static_analysis.py
@@ -15,14 +15,14 @@ from os.path import (join, exists, expanduser, abspath, split, splitext,
 
 class CallDefNode(object):
     def __init__(self, callname, lineno, docstr, doclineno, doclineno_end,
-                 argnames=None):
+                 args=None):
         self.callname = callname
         self.lineno = lineno
         self.docstr = docstr
         self.doclineno = doclineno
         self.doclineno_end = doclineno_end
         self.lineno_end = None
-        self.argnames = argnames
+        self.args = args
 
     # def __str__(self):
     #     return '{}[{}:{}][{}]'.format(
@@ -109,15 +109,10 @@ class TopLevelVisitor(ast.NodeVisitor):
         else:
             callname = self._current_classname + '.' + node.name
 
-        if six.PY2:
-            argnames = [a.id for a in node.args.args]
-        else:
-            argnames = [a.arg for a in node.args.args]
-
         lineno = self._workaround_func_lineno(node)
         docstr, doclineno, doclineno_end = self._get_docstring(node)
         calldef = CallDefNode(callname, lineno, docstr, doclineno,
-                              doclineno_end, argnames=argnames)
+                              doclineno_end, args=node.args)
         self.calldefs[callname] = calldef
 
         self._finish_queue.append(calldef)

--- a/xdoctest/static_analysis.py
+++ b/xdoctest/static_analysis.py
@@ -14,13 +14,15 @@ from os.path import (join, exists, expanduser, abspath, split, splitext,
 
 
 class CallDefNode(object):
-    def __init__(self, callname, lineno, docstr, doclineno, doclineno_end):
+    def __init__(self, callname, lineno, docstr, doclineno, doclineno_end,
+                 argnames=None):
         self.callname = callname
         self.lineno = lineno
         self.docstr = docstr
         self.doclineno = doclineno
         self.doclineno_end = doclineno_end
         self.lineno_end = None
+        self.argnames = argnames
 
     # def __str__(self):
     #     return '{}[{}:{}][{}]'.format(
@@ -35,6 +37,9 @@ class TopLevelVisitor(ast.NodeVisitor):
     References:
         # For other visit_<classname> values see
         http://greentreesnakes.readthedocs.io/en/latest/nodes.html
+
+    CommandLine:
+        python -m xdoctest.static_analysis TopLevelVisitor
 
     Example:
         >>> from xdoctest.static_analysis import *  # NOQA
@@ -104,10 +109,15 @@ class TopLevelVisitor(ast.NodeVisitor):
         else:
             callname = self._current_classname + '.' + node.name
 
+        if six.PY2:
+            argnames = [a.id for a in node.args.args]
+        else:
+            argnames = [a.arg for a in node.args.args]
+
         lineno = self._workaround_func_lineno(node)
         docstr, doclineno, doclineno_end = self._get_docstring(node)
         calldef = CallDefNode(callname, lineno, docstr, doclineno,
-                              doclineno_end)
+                              doclineno_end, argnames=argnames)
         self.calldefs[callname] = calldef
 
         self._finish_queue.append(calldef)

--- a/xdoctest/utils.py
+++ b/xdoctest/utils.py
@@ -84,6 +84,18 @@ class CaptureStdout(object):
         >>> print('dont capture look of disapproval ಠ_ಠ')
         >>> assert isinstance(self.text, six.text_type)
         >>> assert self.text == text + '\n', 'failed capture text'
+
+    Example:
+        >>> self = CaptureStdout(supress=False)
+        >>> with self:
+        ...     print('I am captured and printed in stdout')
+        >>> assert self.text.strip() == 'I am captured and printed in stdout'
+
+    Example:
+        >>> self = CaptureStdout(supress=True, enabled=False)
+        >>> with self:
+        ...     print('dont capture')
+        >>> assert self.text is None
     """
     def __init__(self, supress=True, enabled=True):
         self.enabled = enabled

--- a/xdoctest/utils.py
+++ b/xdoctest/utils.py
@@ -16,6 +16,9 @@ def ensure_unicode(text):
     References:
         http://stackoverflow.com/questions/12561063/python-extract-data-from-file
 
+    CommandLine:
+        python -m xdoctest.utils ensure_unicode
+
     Example:
         >>> from xdoctest.utils import *
         >>> assert ensure_unicode('my ünicôdé strįng') == 'my ünicôdé strįng'
@@ -133,7 +136,7 @@ def indent(text, prefix='    '):
         str: indented text
 
     CommandLine:
-        python -m util_str indent
+        python -m xdoctest.utils ensure_unicode
 
     Example:
         >>> text = 'Lorem ipsum\ndolor sit amet'
@@ -457,3 +460,11 @@ def color_text(text, color):
         import warnings
         warnings.warn('pygments is not installed')
         return text
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python -m xdoctest.utils
+    """
+    import xdoctest
+    xdoctest.doctest_module(__file__)


### PR DESCRIPTION
Functionality that allows functions without args to be run by `xdoc.doctest_module` if you specify that function name on the command line (even if they don't have a doctest). 

TODO:
-[x] add tests
-[x] allow it work as long as all args are defaulted kwargs?
-[x] Better text output in the runner?