### PR TITLE
Add missing sys import on python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ def native_mb_python_tag(plat_impl=None, version_info=None):
             else:
                 abi = 'm'
         else:
+            import sys
             if sys.version_info[:2] >= (3, 8):
                 # bpo-36707: 3.8 dropped the m flag
                 abi = ''


### PR DESCRIPTION
Otherwise this failure occurs on test native_mb_python_tag:0

   File "rpmbuild/BUILD/xdoctest-0.15.4/setup.py", line 173, in native_mb_python_tag
     if sys.version_info[:2] >= (3, 8):

   UnboundLocalError: local variable 'sys' referenced before assignment