### PR TITLE
Fix test failure if pytest's flaky plugin is installed

### DIFF
--- a/testing/test_pytest_cli.py
+++ b/testing/test_pytest_cli.py
@@ -45,11 +45,8 @@ def test_simple_pytest_import_error_cli():
     This test case triggers an excessively long callback in xdoctest <
     dev/0.15.7
 
-    xdoctest ~/code/xdoctest/testing/test_pytest_cli.py test_simple_pytest_import_error_cli
-
-    import sys, ubelt
-    sys.path.append(ubelt.expandpath('~/code/xdoctest/testing'))
-    from test_pytest_cli import *  # NOQA
+    CommandLine:
+        xdoctest ~/code/xdoctest/testing/test_pytest_cli.py test_simple_pytest_import_error_cli
     """
     module_text = utils.codeblock(
         '''
@@ -67,15 +64,14 @@ def test_simple_pytest_import_error_cli():
             """
         ''')
     temp_module = util_misc.TempModule(module_text, modname='imperr_test_mod')
-    command = sys.executable + ' -m pytest -p no:flaky -v -s --xdoctest-verbose=3 --xdoctest ' + temp_module.dpath
+    command = sys.executable + ' -m pytest -v -s --xdoctest-verbose=3 --xdoctest ' + temp_module.dpath
     print(command)
     info = cmd(command)
+    # We patched doctest_example so it no longer outputs this in the traceback
+    assert 'util_import' not in info['out']
     print(info['out'])
-
-    # info = cmd('pytest --xdoctest ' + temp_module.modpath)
-    # print(info['out'])
-
-    assert info['ret'] == 1
+    # Note: flaky changes the return code from 1 to 3, so test non-zero
+    assert info['ret'] != 0
 
 
 def test_simple_pytest_syntax_error_cli():
@@ -96,9 +92,11 @@ def test_simple_pytest_syntax_error_cli():
     temp_module = util_misc.TempModule(module_text)
     info = cmd(sys.executable + ' -m pytest --xdoctest ' + temp_module.dpath)
     print(info['out'])
+    assert info['ret'] != 0
 
     info = cmd(sys.executable + ' -m pytest --xdoctest ' + temp_module.modpath)
     print(info['out'])
+    assert info['ret'] != 0
 
 
 def test_simple_pytest_import_error_no_xdoctest():
@@ -114,10 +112,11 @@ def test_simple_pytest_import_error_no_xdoctest():
     temp_module = util_misc.TempModule(module_text)
     info = cmd(sys.executable + ' -m pytest ' + temp_module.modpath)
     print(info['out'])
+    assert info['ret'] != 0
 
-    info = cmd('pytest ' + temp_module.dpath)
+    info = cmd(sys.executable + ' -m pytest ' + temp_module.dpath)
     print(info['out'])
-    # assert info['ret'] == 0
+    assert info['ret'] != 0
 
 
 def test_simple_pytest_syntax_error_no_xdoctest():
@@ -133,7 +132,8 @@ def test_simple_pytest_syntax_error_no_xdoctest():
     temp_module = util_misc.TempModule(module_text)
     info = cmd(sys.executable + ' -m pytest ' + temp_module.modpath)
     print(info['out'])
+    assert info['ret'] != 0
 
     info = cmd(sys.executable + ' -m pytest ' + temp_module.dpath)
     print(info['out'])
-    # assert info['ret'] == 0
+    assert info['ret'] != 0

--- a/testing/test_pytest_cli.py
+++ b/testing/test_pytest_cli.py
@@ -67,7 +67,7 @@ def test_simple_pytest_import_error_cli():
             """
         ''')
     temp_module = util_misc.TempModule(module_text, modname='imperr_test_mod')
-    command = sys.executable + ' -m pytest -v -s --xdoctest-verbose=3 --xdoctest ' + temp_module.dpath
+    command = sys.executable + ' -m pytest -p no:flaky -v -s --xdoctest-verbose=3 --xdoctest ' + temp_module.dpath
     print(command)
     info = cmd(command)
     print(info['out'])


### PR DESCRIPTION
Disable pytest's flaky plugin in test_simple_pytest_import_error_cli
in order to fix a test failure due to it mangling pytest's return code
on import error.