### PR TITLE
Fix Pytest 8 compatibility

### DIFF
--- a/xdoctest/plugin.py
+++ b/xdoctest/plugin.py
@@ -111,29 +111,29 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(file_path, parent):
     config = parent.config
-    if path.ext == ".py":
+    if file_path.suffix == ".py":
         if config.option.xdoctestmodules:
             if hasattr(XDoctestModule, 'from_parent'):
-                return XDoctestModule.from_parent(parent, fspath=path)
+                return XDoctestModule.from_parent(parent, path=file_path)
             else:
-                return XDoctestModule(path, parent)
-    elif _is_xdoctest(config, path, parent):
+                return XDoctestModule(file_path, parent)
+    elif _is_xdoctest(config, file_path, parent):
         if hasattr(XDoctestTextfile, 'from_parent'):
-            return XDoctestTextfile.from_parent(parent, fspath=path)
+            return XDoctestTextfile.from_parent(parent, path=file_path)
         else:
-            return XDoctestTextfile(path, parent)
+            return XDoctestTextfile(file_path, parent)
 
 
 def _is_xdoctest(config, path, parent):
     matched = False
-    if path.ext in ('.txt', '.rst') and parent.session.isinitpath(path):
+    if path.suffix in ('.txt', '.rst') and parent.session.isinitpath(path):
         matched = True
     else:
         globs = config.getoption("xdoctestglob")
         for glob in globs:
-            if path.check(fnmatch=glob):
+            if path.match(glob):
                 matched = True
                 break
     return matched


### PR DESCRIPTION
Pytest is moving away from `py.path.local` to `pathlib.Path`.

This causes warnings when running tests on Pytest 7:

```
.venv/lib/python3.10/site-packages/_pytest/nodes.py:140: 481 warnings
  /home/arjan/Development/gaphor/.venv/lib/python3.10/site-packages/_pytest/nodes.py:140: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to XDoctestModule is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().__call__(*k, **kw)
```

See also https://docs.pytest.org/en/7.0.x/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path.

This PR changes the `pytest_collect_file` function to use the pathlib path objects instead.
