### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,15 +152,15 @@ jobs:
         # Xcookie generates an explicit list of environments that will be used
         # for testing instead of using the more concise matrix notation.
         include:
-        - python-version: '3.6'
+        - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
           os: ubuntu-20.04
           arch: auto
-        - python-version: '3.6'
+        - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
           os: macOS-latest
           arch: auto
-        - python-version: '3.6'
+        - python-version: '3.8'
           install-extras: tests-strict,runtime-strict
           os: windows-latest
           arch: auto
@@ -184,11 +184,23 @@ jobs:
           install-extras: tests
           os: windows-latest
           arch: auto
-        - python-version: '3.6'
+        - python-version: '3.8'
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: '3.7'
+        - python-version: '3.9'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.10'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional
+          os: windows-latest
+          arch: auto
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto
@@ -208,15 +220,7 @@ jobs:
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: pypy-3.7
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.6'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.7'
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto
@@ -236,47 +240,19 @@ jobs:
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: pypy-3.7
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: '3.6'
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: '3.7'
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto
-        - python-version: '3.8'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.9'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.10'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: pypy-3.7
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: pypy-3.7
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: pypy-3.7
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: pypy-3.7
+        - python-version: pypy-3.10
           install-extras: tests,optional
           os: windows-latest
           arch: auto

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,11 +7,14 @@
 
 # Required
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 sphinx:
   configuration: docs/source/conf.py
 formats: all
 python:
-  version: 3.7
   install:
   - requirements: requirements/docs.txt
   - method: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ We are currently working on porting this changelog to the specifications in
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Version 1.1.2 - Unreleased
+## Version 1.2.0 - Unreleased
 
 ### Removed
-* Dropped 3.6 and 3.7 support. Now supporting 3.8+ Use xdoctest<=1.1.2 for 3.6
+* Dropped 3.6 and 3.7 support. Now supporting 3.8+. Use xdoctest<=1.1.1 for 3.6
   or 3.7 support.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Version 1.1.2 - Unreleased
 
+### Removed
+* Dropped 3.6 and 3.7 support. Now supporting 3.8+ Use xdoctest<=1.1.2 for 3.6
+  or 3.7 support.
+
 ### Changed
 * Removed dependency on six and got rid of old Python 2 logic
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,16 +14,28 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
     
-    - PYTHON: "C:/Python37-x64"
+    - PYTHON: "C:/Python38-x64"
       ARCH_BITS: "64"
 
-    - PYTHON: "C:/Python36-x64"
+    - PYTHON: "C:/Python39-x64"
       ARCH_BITS: "64"
-    
-    - PYTHON: "C:\\Python36"
+
+    - PYTHON: "C:/Python310-x64"
+      ARCH_BITS: "64"
+
+    - PYTHON: "C:/Python311-x64"
+      ARCH_BITS: "64"
+
+    - PYTHON: "C:\\Python38"
       ARCH_BITS: "32"
 
-    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python39"
+      ARCH_BITS: "32"
+
+    - PYTHON: "C:\\Python310"
+      ARCH_BITS: "32"
+
+    - PYTHON: "C:\\Python311"
       ARCH_BITS: "32"
 
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: Implementation :: CPython",
 ]

--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     setupkw["long_description_content_type"] = "text/x-rst"
     setupkw["license"] = "Apache 2"
     setupkw["packages"] = find_packages("./src")
-    setupkw["python_requires"] = ">=3.6"
+    setupkw["python_requires"] = ">=3.8"
     setupkw["classifiers"] = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -243,8 +243,6 @@ if __name__ == "__main__":
         "Framework :: Pytest",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
* Python 3.6 EOL was 23 Dec 2021
* Python 3.7 EOL was 27 Jun 2023