### PR TITLE
Fix python3.13 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ We are currently working on porting this changelog to the specifications in
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Version 1.1.5 - Unreleased
+## Version 1.1.6 - Unreleased
+
+### Fixed
+* Fixed passing of `flags` as keyword argument to `re.sub` for python 3.13 compliance.
+
+
+## Version 1.1.5 - Released 2024-06-08
 
 ### Changed
 * Minor modification to `xdoctest --version-info` and exposed it in CLI help.

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -634,7 +634,7 @@ def remove_blankline_marker(text):
         '\n{marker}', '{marker}']).format(
             marker=BLANKLINE_MARKER, pos_lb=pos_lb)
     # blankline_pattern = r'(?<=\n)[ ]*{}\n?'.format(re.escape(BLANKLINE_MARKER))
-    new_text = re.sub(blankline_pattern, '\n', text, re.MULTILINE)
+    new_text = re.sub(blankline_pattern, '\n', text, flags=re.MULTILINE)
     return new_text
 
 


### PR DESCRIPTION
Hi, we've been updating our CI to work with python3.13 in preparation for the upcoming release in October.  While doing so we received DeprecationWarnings from `checker.py` passing `count` to `re.sub` as a positional argument. It seems in python3.13 this is [deprecated due to confusion between flags and count](https://github.com/python/cpython/issues/56166).

This PR updates `checker.py` to pass `re.MULTILINE` to `re.sub` with a keyword `flags` argument.  I think the original code intended for this to be a flag rather than a count.  When I tested this with `re.MULTILINE` passed as the 4th argument it interpreted it as an integer of 8 and only replaces 8 occurrences of `BLANKLINE_MAKER`.

```python
>>> from xdoctest.checker import remove_blankline_marker
>>> BLANKLINE_MARKER = '<BLANKLINE>'
>>> BLANKLINE_MARKER_ARR = [BLANKLINE_MARKER] * 10
>>> text='Foo\n'.join(BLANKLINE_MARKER_ARR )
>>> remove_blankline_marker(text)
'\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\nFoo\n<BLANKLINE>Foo\n<BLANKLINE>'
```

Running the test suite against `main` on python 3.13:
```
tests/test_checker.py::test_visible_lines
tests/test_checker.py::test_blankline_accept
tests/test_checker.py::test_blankline_failcase
tests/test_doctest_example.py::test_failed_assign_want
tests/test_doctest_example.py::test_failed_assign_want
tests/test_doctest_example.py::test_eval_expr_capture
tests/test_traceback.py::test_lineno_failcase_gotwant
tests/test_traceback.py::test_lineno_failcase_gotwant
  ~/xdoctest/src/xdoctest/checker.py:637: DeprecationWarning: 'count' is passed as positional argument
    new_text = re.sub(blankline_pattern, '\n', text, re.MULTILINE)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
== 296 passed, 23 skipped, 8 warnings in 43.77s ==
```

Running the test suite against this PR on python 3.13:
```
== 296 passed, 23 skipped in 44.35s ==
```