### PR TITLE
Disable `_pytest.doctest` via the plugin system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Removed `16806_WORKAROUND` as it is not longer needed for Python 3.8+
 * Removed deprecated --xdoc-force-dynamic and --allow-xdoc-dynamic flags
 * Improved speed (~6x) of doctest collection when running in pytest
+* Uses pytest plugin system to disable stdlib doctest instead of monkey patching.
 
 ### Fixed
 * Fixed incorrect return type in docstrings

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -14,9 +14,6 @@ this code is heavilly based on ``pytest/_pytest/doctest.py`` plugin file in
 https://github.com/pytest-dev/pytest
 
 """
-from importlib import import_module
-from inspect import getmembers
-from typing import Union
 import pytest
 from _pytest._code import code
 from _pytest import fixtures

--- a/src/xdoctest/plugin.pyi
+++ b/src/xdoctest/plugin.pyi
@@ -13,10 +13,6 @@ import xdoctest.doctest_example
 __docstubs__: str
 
 
-def monkey_patch_disable_normal_doctest():
-    ...
-
-
 def pytest_configure(config: pytest.Config) -> Generator[None, None, None]:
     ...
 

--- a/src/xdoctest/plugin.pyi
+++ b/src/xdoctest/plugin.pyi
@@ -17,6 +17,10 @@ def monkey_patch_disable_normal_doctest():
     ...
 
 
+def pytest_configure(config: pytest.Config) -> Generator[None, None, None]:
+    ...
+
+
 def pytest_addoption(parser):
     ...
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,6 +3,7 @@ Adapted from the original `pytest/tests/test_doctest.py` module at:
     https://github.com/pytest-dev/pytest
     https://github.com/pytest-dev/pytest/blob/main/tests/test_doctest.py
 """
+import shlex
 import sys
 import _pytest._code
 from xdoctest.plugin import XDoctestItem, XDoctestModule, XDoctestTextfile
@@ -117,6 +118,83 @@ def explicit_testdir():
     # from _pytest.compat import _setup_collect_fakemodule
     # _setup_collect_fakemodule()
     return testdir
+
+
+class TestXDoctestActivation:
+    @pytest.mark.parametrize(('flags', 'load'),
+                             [('', False),
+                              ('--xdoc', True),
+                              ('--doctest-modules', False),
+                              ('--doctest-modules --xdoctest', True)])
+    def test_xdoctest_cli_activation(self, pytester, flags, load):
+        """
+        Activate `xdoctest` via command-line arguments.
+
+        CommandLine:
+            pytest tests/test_plugin.py::TestXDoctestActivation::\
+test_xdoctest_cli_activation
+        """
+        self._check_activation(pytester, flags, load)
+
+    def test_xdoctest_config_activation(self, pytester):
+        """
+        Activate `xdoctest` via config file.
+
+        CommandLine:
+            pytest tests/test_plugin.py::TestXDoctestActivation::\
+test_xdoctest_config_activation
+        """
+        pytester.makepyprojecttoml('''
+        [tool.pytest.ini_options]
+        addopts = '--xdoctest'
+        ''')
+        self._check_activation(pytester, '', True)
+
+    def test_xdoctest_explicit_suppression(self, pytester):
+        """
+        Deactivate `xdoctest` via explictly unloading the plugin on the
+        command line.
+
+        CommandLine:
+            pytest tests/test_plugin.py::TestXDoctestActivation::\
+test_xdoctest_explicit_suppression
+        """
+        pdt_namespace_before = self._get_pytest_doctest_module_dict()
+        try:
+            with pytest.raises(pytest.UsageError):
+                # Can't parse the `--xdoc` flag with `xdoctest` disabled
+                self._check_activation(pytester, '--xdoc -p no:xdoctest', False)
+        finally:
+            # Check that `_pytest.doctest` is untouched
+            pdt_namespace_after = self._get_pytest_doctest_module_dict()
+            assert pdt_namespace_before == pdt_namespace_after
+
+    def _check_activation(self, pytester, flags, load):
+        """
+        Check that the ``flags`` result in :py:mod:`xdoctest.plugin`
+        being ``load``-ed if true and not loaded if false.  Also check
+        that it leaves :py:mod:`_pytest.doctest` untouched.
+        """
+        pdt_namespace_before = self._get_pytest_doctest_module_dict()
+        try:
+            config = pytester.parseconfigure(*shlex.split(flags))
+            manager = config.pluginmanager
+            # If the plugin is not active, it unsets itself
+            assert (manager.get_plugin('xdoctest') is not None) == load
+            # Otherwise, it unsets other doctest plugins
+            if not load:
+                return
+            assert manager.get_plugin('doctest') is None
+        finally:
+            # Also check that `_pytest.doctest` is untouched
+            pdt_namespace_after = self._get_pytest_doctest_module_dict()
+            assert pdt_namespace_before == pdt_namespace_after
+
+    @staticmethod
+    def _get_pytest_doctest_module_dict():
+        from _pytest import doctest
+
+        return dict(vars(doctest))
 
 
 class TestXDoctest:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -171,20 +171,16 @@ test_xdoctest_explicit_suppression
 
     def _check_activation(self, pytester, flags, load):
         """
-        Check that the ``flags`` result in :py:mod:`xdoctest.plugin`
-        being ``load``-ed if true and not loaded if false.  Also check
-        that it leaves :py:mod:`_pytest.doctest` untouched.
+        Check that if :py:mod:`xdoctest.plugin` is ``load``-ed,
+        :py:mod:`_pytest.doctest` is unloaded but otherwise untouched.
         """
         pdt_namespace_before = self._get_pytest_doctest_module_dict()
         try:
             config = pytester.parseconfigure(*shlex.split(flags))
             manager = config.pluginmanager
-            # If the plugin is not active, it unsets itself
-            assert (manager.get_plugin('xdoctest') is not None) == load
-            # Otherwise, it unsets other doctest plugins
-            if not load:
-                return
-            assert manager.get_plugin('doctest') is None
+            # When `--xdoctest` is set, it unsets other doctest plugins
+            if load:
+                assert manager.get_plugin('doctest') is None
         finally:
             # Also check that `_pytest.doctest` is untouched
             pdt_namespace_after = self._get_pytest_doctest_module_dict()


### PR DESCRIPTION
Closes #173.

- `src/xdoctest/plugin.py[i]`:
  - `monkey_patch_disable_normal_doctest()`
     - ~~No longer used in the code~~
     - ~~Added note in the docstring stating its side effects and deprecation~~
     - **Removed**
  - `pytest_configure()`:  
    New `pytest` API function for:
    - Checking `config.options` for whether `xdoctest` is activated, instead of checking `sys.argv`
    - Deactivating (unregistering) other ~~unrelated doctest plugins (e.g. `_pytest.doctest`)~~ **plugins known to be incompatible (currently just `_pytest.doctest`)** if yes
    - ~~Deactivating (unregistering) the `xdoctest` plugin itself if no~~
- `tests/test_plugin.py::TestXDoctestActivation`:  
  New test class for testing the (de-)activation of ~~the `xdoctest` plugin~~ **incompatible plugins when `xdoctest` is used**:
  - `.test_xdoctest_cli_activation()`:  
    Test toggling it via command-line arguments
  - `.test_xdoctest_config_activation()`:  
    Test activating it via config file (~~`pyproject.toml`~~ **`pytest.ini`**)
  - `.test_xdoctest_explicit_suppression()`:  
    Test suppressing it via `-p no:xdoctest`