### PR TITLE
Use `asyncio.Runner` on Python>=3.11

### DIFF
--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -962,19 +962,21 @@ class DocTest:
                                         exec(code, test_globals)
                             except BaseException:
                                 # close the asyncio runner (exception)
-                                if asyncio_runner is not None:
-                                    try:
-                                        asyncio_runner.close()
-                                    finally:
-                                        asyncio_runner = None
+                                if not runstate['ASYNC'] or not part.want:
+                                    if asyncio_runner is not None:
+                                        try:
+                                            asyncio_runner.close()
+                                        finally:
+                                            asyncio_runner = None
                                 raise
-                            if not runstate['ASYNC']:
-                                # close the asyncio runner (top-level await)
-                                if asyncio_runner is not None:
-                                    try:
-                                        asyncio_runner.close()
-                                    finally:
-                                        asyncio_runner = None
+                            else:
+                                if not runstate['ASYNC']:
+                                    # close the asyncio runner (top-level await)
+                                    if asyncio_runner is not None:
+                                        try:
+                                            asyncio_runner.close()
+                                        finally:
+                                            asyncio_runner = None
 
                         # Record any standard output and "got_eval" produced by
                         # this doctest_part.

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -918,6 +918,13 @@ class DocTest:
                     # if on_error == 'raise':
                     #     raise
                 try:
+                    if not runstate['ASYNC']:
+                        # close the asyncio runner (context exit)
+                        if asyncio_runner is not None:
+                            try:
+                                asyncio_runner.close()
+                            finally:
+                                asyncio_runner = None
                     # Execute the doctest code
                     try:
                         # NOTE: For code passed to eval or exec, there is no
@@ -930,13 +937,6 @@ class DocTest:
                             # can compared to a "want" statement.
                             # print('part.compile_mode = {!r}'.format(part.compile_mode))
                             is_coroutine = code.co_flags & CO_COROUTINE == CO_COROUTINE
-                            if not runstate['ASYNC']:
-                                # close the asyncio runner (context exit)
-                                if asyncio_runner is not None:
-                                    try:
-                                        asyncio_runner.close()
-                                    finally:
-                                        asyncio_runner = None
                             if is_coroutine or runstate['ASYNC']:
                                 if is_running_in_loop:
                                     raise exceptions.ExistingEventLoopError(
@@ -954,13 +954,6 @@ class DocTest:
                                     got_eval = asyncio_runner.run(corofunc())
                                 else:
                                     asyncio_runner.run(corofunc())
-                                if not runstate['ASYNC']:
-                                    # close the asyncio runner (top-level await)
-                                    if asyncio_runner is not None:
-                                        try:
-                                            asyncio_runner.close()
-                                        finally:
-                                            asyncio_runner = None
                             else:
                                 if part.compile_mode == 'eval':
                                     got_eval = eval(code, test_globals)
@@ -997,6 +990,13 @@ class DocTest:
                                 asyncio_runner = None
                         raise
                     else:
+                        if not runstate['ASYNC']:
+                            # close the asyncio runner (top-level await)
+                            if asyncio_runner is not None:
+                                try:
+                                    asyncio_runner.close()
+                                finally:
+                                    asyncio_runner = None
                         """
                         TODO:
                             [ ] - Delay got-want failure until the end of the

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -938,12 +938,12 @@ class DocTest:
                                     else:
                                         asyncio_runner.run(eval(code, test_globals))
                                 else:
-                                    async def coro():
+                                    async def corofunc():
                                         return eval(code, test_globals)
                                     if part.compile_mode == 'eval':
-                                        got_eval = asyncio_runner.run(coro())
+                                        got_eval = asyncio_runner.run(corofunc())
                                     else:
-                                        asyncio_runner.run(coro())
+                                        asyncio_runner.run(corofunc())
                             else:
                                 # close the asyncio runner (context exit)
                                 if asyncio_runner is not None:

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -61,8 +61,9 @@ def _create_asyncio_runner():
             if asyncio._get_running_loop() is not None:
                 msg = "Runner.run() cannot be called from a running event loop"
                 raise RuntimeError(msg)
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
+            if self._loop is None:
+                self._loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop)
             return self._loop.run_until_complete(coro)
 
         def close(self):

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -929,14 +929,14 @@ class DocTest:
                             # expect it to return an object with a repr that
                             # can compared to a "want" statement.
                             # print('part.compile_mode = {!r}'.format(part.compile_mode))
-                            if not runstate['ASYNC']:
-                                # close the asyncio runner (context exit)
-                                if asyncio_runner is not None:
-                                    try:
-                                        asyncio_runner.close()
-                                    finally:
-                                        asyncio_runner = None
                             try:
+                                if not runstate['ASYNC']:
+                                    # close the asyncio runner (context exit)
+                                    if asyncio_runner is not None:
+                                        try:
+                                            asyncio_runner.close()
+                                        finally:
+                                            asyncio_runner = None
                                 is_coroutine = code.co_flags & CO_COROUTINE == CO_COROUTINE
                                 if is_coroutine or runstate['ASYNC']:
                                     if is_running_in_loop:
@@ -961,8 +961,8 @@ class DocTest:
                                     else:
                                         exec(code, test_globals)
                             except BaseException:
-                                # close the asyncio runner (exception)
                                 if not runstate['ASYNC'] or not part.want:
+                                    # close the asyncio runner (exception)
                                     if asyncio_runner is not None:
                                         try:
                                             asyncio_runner.close()

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -36,7 +36,12 @@ def _asyncio_running():
     if "asyncio" in sys.modules:
         import asyncio
 
-        return asyncio._get_running_loop() is not None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:  # no running event loop
+            loop = None
+
+        return loop is not None
 
     return False
 

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -933,8 +933,10 @@ class DocTest:
                             if not runstate['ASYNC']:
                                 # close the asyncio runner (context exit)
                                 if asyncio_runner is not None:
-                                    asyncio_runner.close()
-                                    asyncio_runner = None
+                                    try:
+                                        asyncio_runner.close()
+                                    finally:
+                                        asyncio_runner = None
                             if is_coroutine or runstate['ASYNC']:
                                 if is_running_in_loop:
                                     raise exceptions.ExistingEventLoopError(

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -802,8 +802,8 @@ class DocTest:
         #     runstate['SKIP'] = True
 
         needs_capture = True
-        is_running_in_loop = _asyncio_running()
         asyncio_runner = None
+        is_running_in_loop = _asyncio_running()
 
         DEBUG = global_state.DEBUG_DOCTEST
 

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -938,18 +938,15 @@ class DocTest:
                                         )
                                 if asyncio_runner is None:
                                     asyncio_runner = _create_asyncio_runner()
-                                if is_coroutine:
-                                    if part.compile_mode == 'eval':
-                                        got_eval = asyncio_runner.run(eval(code, test_globals))
+                                async def corofunc():
+                                    if is_coroutine:
+                                        return await eval(code, test_globals)
                                     else:
-                                        asyncio_runner.run(eval(code, test_globals))
-                                else:
-                                    async def corofunc():
                                         return eval(code, test_globals)
-                                    if part.compile_mode == 'eval':
-                                        got_eval = asyncio_runner.run(corofunc())
-                                    else:
-                                        asyncio_runner.run(corofunc())
+                                if part.compile_mode == 'eval':
+                                    got_eval = asyncio_runner.run(corofunc())
+                                else:
+                                    asyncio_runner.run(corofunc())
                             else:
                                 # close the asyncio runner (context exit)
                                 if asyncio_runner is not None:
@@ -962,11 +959,16 @@ class DocTest:
                                             part.orig_lines
                                             )
                                     asyncio_runner = _create_asyncio_runner()
+                                    async def corofunc():
+                                        if is_coroutine:
+                                            return await eval(code, test_globals)
+                                        else:
+                                            return eval(code, test_globals)
                                     try:
                                         if part.compile_mode == 'eval':
-                                            got_eval = asyncio_runner.run(eval(code, test_globals))
+                                            got_eval = asyncio_runner.run(corofunc())
                                         else:
-                                            asyncio_runner.run(eval(code, test_globals))
+                                            asyncio_runner.run(corofunc())
                                     finally:
                                         try:
                                             asyncio_runner.close()

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -986,11 +986,20 @@ class DocTest:
                         if part.want:
                             # A failure may be expected if the traceback
                             # matches the part's want statement.
-                            exception = sys.exc_info()
-                            traceback.format_exception_only(*exception[:2])
-                            exc_got = traceback.format_exception_only(*exception[:2])[-1]
-                            want = part.want
-                            checker.check_exception(exc_got, want, runstate)
+                            try:
+                                exception = sys.exc_info()
+                                traceback.format_exception_only(*exception[:2])
+                                exc_got = traceback.format_exception_only(*exception[:2])[-1]
+                                want = part.want
+                                checker.check_exception(exc_got, want, runstate)
+                            except BaseException:
+                                # close the asyncio runner (checker exception)
+                                if asyncio_runner is not None:
+                                    try:
+                                        asyncio_runner.close()
+                                    finally:
+                                        asyncio_runner = None
+                                raise
                         else:
                             raise
                     else:

--- a/src/xdoctest/utils/__init__.py
+++ b/src/xdoctest/utils/__init__.py
@@ -7,6 +7,7 @@ This __init__ file is generated using mkinit:
 
     mkinit xdoctest.utils
 """
+from xdoctest.utils import util_asyncio
 from xdoctest.utils import util_import
 from xdoctest.utils import util_misc
 from xdoctest.utils import util_mixins

--- a/src/xdoctest/utils/util_asyncio.py
+++ b/src/xdoctest/utils/util_asyncio.py
@@ -1,0 +1,73 @@
+"""
+Utilities related to async support
+"""
+import asyncio
+import sys
+
+
+# see asyncio.runners.Runner
+class FallbackRunner:
+    """A fallback implementation of :class:`asyncio.Runner` for Python<3.11."""
+
+    def __init__(self):
+        self._loop = None
+
+    def run(self, coro):
+        """Run code in the embedded event loop."""
+        if running():
+            msg = 'Runner.run() cannot be called from a running event loop'
+            raise RuntimeError(msg)
+        if self._loop is None:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+        return self._loop.run_until_complete(coro)
+
+    def close(self):
+        """Shutdown and close event loop."""
+        loop = self._loop
+        if loop is None:
+            return
+        try:
+            _cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            if sys.version_info >= (3, 9):
+                loop.run_until_complete(loop.shutdown_default_executor())
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+            self._loop = None
+
+
+# see asyncio.runners._cancel_all_tasks
+def _cancel_all_tasks(loop):
+    to_cancel = asyncio.all_tasks(loop)
+    if not to_cancel:
+        return
+    for task in to_cancel:
+        task.cancel()
+    loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler({
+                'message': 'unhandled exception during asyncio.run() shutdown',
+                'exception': task.exception(),
+                'task': task,
+            })
+
+
+def running():
+    """Return :data:`True` if there is a running event loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # no running event loop
+        loop = None
+
+    return loop is not None
+
+
+if sys.version_info >= (3, 11):
+    from asyncio import Runner
+else:
+    Runner = FallbackRunner

--- a/src/xdoctest/utils/util_asyncio.pyi
+++ b/src/xdoctest/utils/util_asyncio.pyi
@@ -1,0 +1,21 @@
+import sys
+from typing import Any, TypeVar, final
+if sys.version_info >= (3, 9):
+    from collections.abc import Coroutine
+else:
+    from typing import Coroutine
+
+_T = TypeVar('_T')
+
+@final
+class FallbackRunner:
+    def __init__(self) -> None: ...
+    def run(self, coro: Coroutine[Any, Any, _T]) -> _T: ...
+    def close(self) -> None: ...
+
+def running() -> bool: ...
+
+if sys.version_info >= (3, 11):
+    from asyncio import Runner
+else:
+    Runner = FallbackRunner


### PR DESCRIPTION
This PR replaces the helper methods added in #176 by using [`asyncio.Runner`](https://docs.python.org/3/library/asyncio-runner.html#asyncio.Runner) directly on Python>=3.11 and using a fallback implementation on Python<3.11. This makes it easier to simplify the code in the future when Python<3.11 support is dropped - simply removing the fallback implementation would be sufficient.

<details>
<summary>outdated</summary>

It also prevents importing asyncio before the first demand, which speeds up xdoctest import and makes it more pleasant to use. And includes some nice fixes.

Before:

```fish
user@domain ~/xdoctest (main)> time python3.12 -c "import xdoctest"

________________________________________________________
Executed in  251.84 millis    fish           external
   usr time  223.97 millis  521.00 micros  223.45 millis
   sys time   27.03 millis   99.00 micros   26.93 millis
```

After:

```fish
user@domain ~/xdoctest (main)> time python3.12 -c "import xdoctest"

________________________________________________________
Executed in  115.10 millis    fish           external
   usr time  104.85 millis  491.00 micros  104.36 millis
   sys time   10.04 millis  101.00 micros    9.94 millis
```

</details>