### PR TITLE
Add static doctest discovery support for async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Version 1.3.1 - Unreleased
 
+### Fixed
+* Static discovery now includes doctests defined in `async def` functions.
+
 
 ## Version 1.3.0 - Released 2025-09-08
 

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -239,6 +239,13 @@ class TopLevelVisitor(ast.NodeVisitor):
 
         self._finish_queue.append(calldef)
 
+    def visit_AsyncFunctionDef(self, node):
+        """
+        Args:
+            node (ast.AsyncFunctionDef):
+        """
+        self.visit_FunctionDef(node)
+
     def visit_ClassDef(self, node):
         """
         Args:

--- a/src/xdoctest/static_analysis.pyi
+++ b/src/xdoctest/static_analysis.pyi
@@ -56,6 +56,9 @@ class TopLevelVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         ...
 
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        ...
+
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         ...
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -596,6 +596,40 @@ def test_semicolon_line():
     status = example.run(verbose=0)
     assert status['passed']
 
+def test_collect_async_function_doctest():
+    with utils.TempDir() as temp:
+        dpath = temp.dpath
+        modpath = join(dpath, 'test_collect_async_function_doctest.py')
+        source = utils.codeblock(
+            '''
+            """
+            >>> 1 + 0
+            1
+            """
+
+
+            def a():
+                """
+                >>> a()
+                1
+                """
+                return 1
+
+
+            async def b():
+                """
+                >>> b()
+                2
+                """
+                return 1
+            ''')
+        with open(modpath, 'w') as file:
+            file.write(source)
+
+        doctests = list(core.parse_doctestables(modpath, style='freeform'))
+        callnames = {test.callname for test in doctests}
+        assert callnames == {'__doc__', 'a', 'b'}
+
 
 if __name__ == '__main__':
     """
@@ -606,3 +640,4 @@ if __name__ == '__main__':
     """
     import xdoctest  # NOQA
     xdoctest.doctest_module(__file__)
+

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -127,6 +127,23 @@ def test_mod_lineno2():
     assert calldefs['decor4'].doclineno_end == 38
 
 
+def test_async_function_docstr_collection():
+    source = utils.codeblock(
+        '''
+        async def b():
+            """
+            >>> b()
+            2
+            """
+            return 1
+        ''')
+
+    self = static.TopLevelVisitor.parse(source)
+    assert 'b' in self.calldefs
+    assert self.calldefs['b'].doclineno == 2
+    assert self.calldefs['b'].doclineno_end == 5
+
+
 if __name__ == '__main__':
     """
     CommandLine:


### PR DESCRIPTION
### Motivation
- Static analysis did not collect call definitions or docstrings for `async def` functions, so doctests embedded inside async functions were not discovered during static parsing.

### Description
- Add `TopLevelVisitor.visit_AsyncFunctionDef` that delegates to `visit_FunctionDef` so `async def` nodes are treated the same as regular functions for callname/docstring extraction (`src/xdoctest/static_analysis.py`).
- Update the type stub to declare `visit_AsyncFunctionDef` on `TopLevelVisitor` (`src/xdoctest/static_analysis.pyi`).
- Add unit tests to verify static collection of async function docstrings (`tests/test_static.py::test_async_function_docstr_collection`) and that `core.parse_doctestables` discovers async-function doctests alongside module and sync-function doctests (`tests/test_core.py::test_collect_async_function_doctest`).
- Update `CHANGELOG.md` under the unreleased section to mention the fix.

### Testing
- Installed the package in editable mode with `pip install -e .` and ran the new targeted tests with `python run_tests.py tests/test_static.py::test_async_function_docstr_collection tests/test_core.py::test_collect_async_function_doctest` which exercised the change.
- Ran the full test suite with `python run_tests.py` and observed all tests passing: `315 passed, 23 skipped, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c90ee0180832daa069c3b2287f299)