### PR TITLE
More typing and an important bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 * Fixed issue #181 where comment indentation could cause parsing issues.
+* Fix traceback rewriting for exceptions raised in earlier doctest parts
+
+### Changed
+* Bump minimum pytest to 6.2.5
+* Much more static typing
 
 
 ## Version 1.3.2 - Released 2026-03-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ ignore-words-list = ['wont', 'cant', 'ANS', 'doesnt', 'arent', 'ans', 'thats', '
 [tool.mypy]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "xdoctest._tokenize"
+ignore_errors = true
+
 [tool.ty.rules]
 unused-type-ignore-comment = "ignore"
 unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,21 @@ ignore-words-list = ['wont', 'cant', 'ANS', 'doesnt', 'arent', 'ans', 'thats', '
 
 [tool.mypy]
 ignore_missing_imports = true
+exclude = '''(?x)(
+    ^tests/pybind11_test($|/)
+)'''
 
 [[tool.mypy.overrides]]
 module = "xdoctest._tokenize"
 ignore_errors = true
 
 # TODO: ingore tests/pybind11_test
+
+[tool.ty.src]
+exclude = [
+    # TODO: ignore tests/pybind11_test
+    "tests/pybind11_test",
+]
 
 [tool.ty.rules]
 unused-type-ignore-comment = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,14 @@ ignore_missing_imports = true
 module = "xdoctest._tokenize"
 ignore_errors = true
 
+# TODO: ingore tests/pybind11_test
+
 [tool.ty.rules]
 unused-type-ignore-comment = "ignore"
 unresolved-import = "ignore"
 
 [[tool.ty.overrides]]
-include = ["src/xdoctest/_tokenize.py"]
+include = ["src/xdoctest/_tokenize.py", "pybind11_test"]
 [tool.ty.overrides.rules]
 unsupported-operator = "ignore"
 invalid-assignment = "ignore"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,6 +6,6 @@
 
 pytest >= 9.0.0 ; python_version < '4.0.0'  and python_version >= '3.14.0' # Python 3.14+
 pytest >= 6.2.5 ; python_version < '3.14.0' and python_version >= '3.10.0' # Python 3.10 - 3.13
-pytest >= 4.6.0 ; python_version < '3.10.0' and python_version >= '3.7.0'  # Python 3.7-3.9
+pytest >= 6.2.5 ; python_version < '3.10.0' and python_version >= '3.7.0'  # Python 3.7-3.9
 
 pytest-cov >= 3.0.0

--- a/src/xdoctest/_tokenize.py
+++ b/src/xdoctest/_tokenize.py
@@ -166,13 +166,13 @@ class StopTokenizing(Exception): pass
 
 class Untokenizer:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.tokens = []
         self.prev_row = 1
         self.prev_col = 0
         self.encoding = None
 
-    def add_whitespace(self, start):
+    def add_whitespace(self, start) -> None:
         row, col = start
         if row < self.prev_row or row == self.prev_row and col < self.prev_col:
             raise ValueError("start ({},{}) precedes previous end ({},{})"
@@ -222,7 +222,7 @@ class Untokenizer:
                 self.prev_col = 0
         return "".join(self.tokens)
 
-    def compat(self, token, iterable):
+    def compat(self, token, iterable) -> None:
         indents = []
         toks_append = self.tokens.append
         startline = token[0] in (NEWLINE, NL)
@@ -431,7 +431,7 @@ def tokenize(readline):
     return _tokenize(rl_gen.__next__, encoding)
 
 
-def _tokenize(readline, encoding):
+def _tokenize(readline, encoding) -> None:
     lnum = parenlev = continued = 0
     numchars = '0123456789'
     contstr, needcont = '', 0
@@ -622,15 +622,15 @@ def generate_tokens(readline):
     """
     return _tokenize(readline, None)
 
-def main():
+def main() -> None:
     import argparse
 
     # Helper error handling routines
-    def perror(message):
+    def perror(message) -> None:
         sys.stderr.write(message)
         sys.stderr.write('\n')
 
-    def error(message, filename=None, location=None):
+    def error(message, filename=None, location=None) -> None:
         if location:
             args = (filename,) + location + (message,)
             perror("%s:%d:%d: error: %s" % args)
@@ -683,7 +683,7 @@ def main():
         perror("unexpected error: %s" % err)
         raise
 
-def _generate_tokens_from_c_tokenizer(source):
+def _generate_tokens_from_c_tokenizer(source) -> None:
     """Tokenize a source reading Python code as unicode strings using the internal C tokenizer"""
     import _tokenize as c_tokenizer  # type: ignore[unresolved-import]
     for info in c_tokenizer.TokenizerIter(source):

--- a/src/xdoctest/_tokenize.py
+++ b/src/xdoctest/_tokenize.py
@@ -431,7 +431,7 @@ def tokenize(readline):
     return _tokenize(rl_gen.__next__, encoding)
 
 
-def _tokenize(readline, encoding) -> None:
+def _tokenize(readline, encoding):
     lnum = parenlev = continued = 0
     numchars = '0123456789'
     contstr, needcont = '', 0
@@ -683,7 +683,7 @@ def main() -> None:
         perror("unexpected error: %s" % err)
         raise
 
-def _generate_tokens_from_c_tokenizer(source) -> None:
+def _generate_tokens_from_c_tokenizer(source):
     """Tokenize a source reading Python code as unicode strings using the internal C tokenizer"""
     import _tokenize as c_tokenizer  # type: ignore[unresolved-import]
     for info in c_tokenizer.TokenizerIter(source):

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -74,7 +74,7 @@ def check_got_vs_want(
     got_stdout: str,
     got_eval: typing.Any = constants.NOT_EVALED,
     runstate: directive.RuntimeState | None = None,
-):
+) -> bool:
     """
     Determines to check against either got_stdout or got_eval, and then does
     the comparison.
@@ -405,10 +405,10 @@ def normalize(
     if runstate is None:
         runstate = directive.RuntimeState()
 
-    def remove_prefixes(regex, text):
+    def remove_prefixes(regex : str | re.Pattern[str], text : str) -> str:
         return re.sub(regex, r'\1\2', text)
 
-    def visible_text(lines):
+    def visible_text(lines : list[str]) -> list[str]:
         # TODO: backspaces
         # Any lines that end with only a carriage return are erased
         return [line for line in lines if not line.endswith('\r')]
@@ -463,7 +463,7 @@ def normalize(
 
     if runstate['NORMALIZE_REPR']:
 
-        def norm_repr(a, b):
+        def norm_repr(a: str, b: str) -> str:
             # If removing quotes would allow for a match, remove them.
             if not _check_match(a, b, runstate):
                 for q in ['"', "'"]:
@@ -513,7 +513,7 @@ class GotWantException(AssertionError):
         self.got = got
         self.want = want
 
-    def _do_a_fancy_diff(self, runstate=None):
+    def _do_a_fancy_diff(self, runstate: directive.RuntimeState | None = None) -> bool:
         # Not unless they asked for a fancy diff.
         got = self.got
         want = self.want

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -405,10 +405,10 @@ def normalize(
     if runstate is None:
         runstate = directive.RuntimeState()
 
-    def remove_prefixes(regex : str | re.Pattern[str], text : str) -> str:
+    def remove_prefixes(regex: str | re.Pattern[str], text: str) -> str:
         return re.sub(regex, r'\1\2', text)
 
-    def visible_text(lines : list[str]) -> list[str]:
+    def visible_text(lines: list[str]) -> list[str]:
         # TODO: backspaces
         # Any lines that end with only a carriage return are erased
         return [line for line in lines if not line.endswith('\r')]
@@ -513,7 +513,9 @@ class GotWantException(AssertionError):
         self.got = got
         self.want = want
 
-    def _do_a_fancy_diff(self, runstate: directive.RuntimeState | None = None) -> bool:
+    def _do_a_fancy_diff(
+        self, runstate: directive.RuntimeState | None = None
+    ) -> bool:
         # Not unless they asked for a fancy diff.
         got = self.got
         want = self.want

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -38,8 +38,8 @@ from __future__ import annotations
 import difflib
 import re
 import typing
-from collections import OrderedDict
-from typing import Dict, OrderedDict as OrderedDictType, Set, Union
+from typing import Dict, Set
+from typing import OrderedDict as OrderedDictType
 
 from xdoctest import constants, directive, utils
 

--- a/src/xdoctest/constants.py
+++ b/src/xdoctest/constants.py
@@ -43,10 +43,10 @@ class _NOT_EVAL_TYPE:
     def __call__(self, default: object) -> None:
         pass
 
-    def __str__(cls):
+    def __str__(cls) -> str:
         return '<NOT_EVALED>'
 
-    def __repr__(cls):
+    def __repr__(cls) -> str:
         return '<NOT_EVALED>'
 
     def __bool__(self) -> bool:

--- a/src/xdoctest/core.py
+++ b/src/xdoctest/core.py
@@ -51,10 +51,6 @@ DOCTEST_STYLES = [
     # 'numpy',  # TODO
 ]
 
-__docstubs__ = """
-import xdoctest.doctest_example
-"""
-
 
 def parse_freeform_docstr_examples(
     docstr: str,

--- a/src/xdoctest/core.py
+++ b/src/xdoctest/core.py
@@ -31,6 +31,7 @@ import warnings
 from fnmatch import fnmatch
 from os.path import exists
 
+from typing import cast, List
 from xdoctest import (
     doctest_example,
     dynamic_analysis,
@@ -133,13 +134,14 @@ def parse_freeform_docstr_examples(
         >>> examples = list(parse_freeform_docstr_examples(docstr, asone=False))
         >>> assert len(examples) == 3
     """
+    from xdoctest.doctest_part import DoctestPart
 
-    def doctest_from_parts(parts, num, curr_offset):
+    def doctest_from_parts(parts : list[DoctestPart], num: int, curr_offset: int) -> doctest_example.DocTest:
         # FIXME: this will cause line numbers to become misaligned
-        nested = [
-            p.orig_lines
+        nested: list[list[str]] = [
+            cast(List[str], p.orig_lines)
             if p.want is None
-            else p.orig_lines + p.want.splitlines()
+            else cast(List[str], p.orig_lines) + p.want.splitlines()
             for p in parts
         ]
         docsrc = '\n'.join(list(it.chain.from_iterable(nested)))
@@ -319,7 +321,9 @@ def parse_google_docstr_examples(
         yield example
 
 
-def parse_auto_docstr_examples(docstr, *args, **kwargs) -> None:
+def parse_auto_docstr_examples(
+    docstr: str, *args: typing.Any, **kwargs: typing.Any
+) -> typing.Iterator[doctest_example.DocTest]:
     """
     First try to parse google style, but if no tests are found use freeform
     style.
@@ -408,7 +412,6 @@ def parse_docstr_examples(
                 callname, modpath
             )
         )
-    parser: typing.Any
     if style == 'freeform':
         parser = parse_freeform_docstr_examples
     elif style == 'google':
@@ -742,8 +745,9 @@ def parse_doctestables(
     ):
         for callname, calldef in calldefs.items():
             docstr = calldef.docstr
-            if calldef.docstr is not None:
+            if docstr is not None:
                 lineno = calldef.doclineno
+                assert isinstance(lineno, int)
                 example_gen = parse_docstr_examples(
                     docstr,
                     callname=callname,

--- a/src/xdoctest/core.py
+++ b/src/xdoctest/core.py
@@ -30,8 +30,8 @@ import typing
 import warnings
 from fnmatch import fnmatch
 from os.path import exists
+from typing import List, cast
 
-from typing import cast, List
 from xdoctest import (
     doctest_example,
     dynamic_analysis,
@@ -136,7 +136,9 @@ def parse_freeform_docstr_examples(
     """
     from xdoctest.doctest_part import DoctestPart
 
-    def doctest_from_parts(parts : list[DoctestPart], num: int, curr_offset: int) -> doctest_example.DocTest:
+    def doctest_from_parts(
+        parts: list[DoctestPart], num: int, curr_offset: int
+    ) -> doctest_example.DocTest:
         # FIXME: this will cause line numbers to become misaligned
         nested: list[list[str]] = [
             cast(List[str], p.orig_lines)

--- a/src/xdoctest/core.py
+++ b/src/xdoctest/core.py
@@ -319,7 +319,7 @@ def parse_google_docstr_examples(
         yield example
 
 
-def parse_auto_docstr_examples(docstr, *args, **kwargs):
+def parse_auto_docstr_examples(docstr, *args, **kwargs) -> None:
     """
     First try to parse google style, but if no tests are found use freeform
     style.

--- a/src/xdoctest/core.py
+++ b/src/xdoctest/core.py
@@ -414,38 +414,54 @@ def parse_docstr_examples(
                 callname, modpath
             )
         )
-    if style == 'freeform':
-        parser = parse_freeform_docstr_examples
-    elif style == 'google':
-        parser = parse_google_docstr_examples
-    elif style == 'auto':
-        parser = parse_auto_docstr_examples
-    # TODO: epdoc
-    # TODO:
-    # elif style == 'numpy':
-    #     parser = parse_numpy_docstr_examples
-    else:
+
+    if style not in {'freeform', 'google', 'auto'}:
         raise KeyError(
             'Unknown style={}. Valid styles are {}'.format(
                 style, DOCTEST_STYLES
             )
         )
 
-    if global_state.DEBUG_CORE:  # nocover
-        print('parser = {!r}'.format(parser))
-
     n_parsed = 0
     try:
         if parser_kw is None:
             parser_kw = {}
-        for example in parser(
-            docstr,
-            callname=callname,
-            modpath=modpath,
-            fpath=fpath,
-            lineno=lineno,
-            **parser_kw,
-        ):
+
+        # TODO: we should ensure each style parser has the same exact signature.
+
+        if style == 'freeform':
+            examples = parse_freeform_docstr_examples(
+                docstr,
+                callname=callname,
+                modpath=modpath,
+                fpath=fpath,
+                lineno=lineno,
+                **parser_kw,
+            )
+        elif style == 'google':
+            examples = parse_google_docstr_examples(
+                docstr,
+                callname=callname,
+                modpath=modpath,
+                fpath=fpath,
+                lineno=lineno,
+                **parser_kw,
+            )
+        elif style == 'auto':
+            examples = parse_auto_docstr_examples(
+                docstr,
+                callname=callname,
+                modpath=modpath,
+                fpath=fpath,
+                lineno=lineno,
+                **parser_kw,
+            )
+        # TODO: epdoc
+        # TODO:
+        # elif style == 'numpy':
+        #     examples = parse_numpy_docstr_examples(...)
+
+        for example in examples:
             n_parsed += 1
             yield example
     except Exception as ex:

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -922,20 +922,6 @@ def _module_exists(modname: typing.Any) -> bool:
     return exists_flag
 
 
-# __docstubs__ = '''
-# import re
-
-# if hasattr(re, 'Pattern'):
-#     RE_Pattern = re.Pattern
-# else:
-#     # sys.version_info[0:2] <= 3.6
-#     RE_Pattern = type(re.compile('.*'))
-
-# DIRECTIVE_RE: RE_Pattern
-# DIRECTIVE_PATTERNS: list
-# COMMANDS: list
-# '''
-
 COMMANDS = list(DEFAULT_RUNTIME_STATE.keys()) + [
     # Define extra commands that can resolve to a runtime state modification
     'REQUIRES',

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -185,7 +185,7 @@ def named(key: str, pattern: str) -> str:
 # TODO: modify global directive defaults via a config file
 
 
-class RuntimeStateDict(TypedDict):
+class RuntimeStateDict(TypedDict, total=False):
     """
     TypedDict representing the xdoctest runtime state.
 

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -294,7 +294,7 @@ class RuntimeState(utils.NiceRepr):
         })>
     """
 
-    def __init__(self, default_state: RuntimeStateDict | None = None):
+    def __init__(self, default_state: RuntimeStateDict | None = None) -> None:
         """
         Args:
             default_state (None | dict): starting default state, if unspecified
@@ -344,7 +344,7 @@ class RuntimeState(utils.NiceRepr):
                 key
             ]
 
-    def __setitem__(self, key: str, value: bool | set[str]):
+    def __setitem__(self, key: str, value: bool | set[str]) -> None:
         """
         Args:
             key (str):
@@ -358,7 +358,7 @@ class RuntimeState(utils.NiceRepr):
         self,
         reportchoice: ReportStyle,
         state: RuntimeStateDict | None = None,
-    ):
+    ) -> None:
         """
         Args:
             reportchoice (ReportStyle): name of report style. Must be one of
@@ -382,7 +382,7 @@ class RuntimeState(utils.NiceRepr):
                 state_dict[k] = False
         state_dict['REPORT_' + reportchoice.upper()] = True
 
-    def update(self, directives: list[Directive]):
+    def update(self, directives: list[Directive]) -> None:
         """
         Update the runtime state given a set of directives
 
@@ -435,7 +435,7 @@ class Directive(utils.NiceRepr):
         positive: bool = True,
         args: list[str] | None = None,
         inline: bool | None = None,
-    ):
+    ) -> None:
         """
         Args:
             name (str): The name of the directive

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -562,7 +562,7 @@ class Directive(utils.NiceRepr):
         else:
             return '{}{}'.format(prefix, self.name)
 
-    def _unpack_args(self, num : int) -> list[str] | None:
+    def _unpack_args(self, num: int) -> list[str] | None:
         from xdoctest.utils import util_deprecation
 
         util_deprecation.schedule_deprecation(
@@ -584,7 +584,11 @@ class Directive(utils.NiceRepr):
             )
         return self.args
 
-    def effect(self, argv: list[str] | None = None, environ: dict[str, str] | None = None) -> Effect:
+    def effect(
+        self,
+        argv: list[str] | None = None,
+        environ: dict[str, str] | None = None,
+    ) -> Effect:
         from xdoctest.utils import util_deprecation
 
         util_deprecation.schedule_deprecation(

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -562,7 +562,7 @@ class Directive(utils.NiceRepr):
         else:
             return '{}{}'.format(prefix, self.name)
 
-    def _unpack_args(self, num):
+    def _unpack_args(self, num : int) -> list[str] | None:
         from xdoctest.utils import util_deprecation
 
         util_deprecation.schedule_deprecation(
@@ -584,7 +584,7 @@ class Directive(utils.NiceRepr):
             )
         return self.args
 
-    def effect(self, argv=None, environ=None):
+    def effect(self, argv: list[str] | None = None, environ: dict[str, str] | None = None) -> Effect:
         from xdoctest.utils import util_deprecation
 
         util_deprecation.schedule_deprecation(

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -340,7 +340,9 @@ class RuntimeState(utils.NiceRepr):
         if key in self._inline_state:
             return cast(Union[bool, Set[str]], self._inline_state[key])
         else:
-            return cast(Dict[str, Union[bool, Set[str]]], self._global_state)[key]
+            return cast(Dict[str, Union[bool, Set[str]]], self._global_state)[
+                key
+            ]
 
     def __setitem__(self, key: str, value: bool | set[str]):
         """

--- a/src/xdoctest/docstr/docscrape_google.py
+++ b/src/xdoctest/docstr/docscrape_google.py
@@ -519,16 +519,16 @@ def parse_google_argblock(
         >>> assert argdict_list[1]['desc'] == 'a description with a newline'
     """
 
-    def named(key, pattern):
+    def named(key, pattern) -> str:
         return '(?P<{}>{})'.format(key, pattern)
 
-    def optional(pattern):
+    def optional(pattern) -> str:
         return '({})?'.format(pattern)
 
-    def positive_lookahead(pattern):
+    def positive_lookahead(pattern) -> str:
         return '(?={})'.format(pattern)
 
-    def regex_or(patterns):
+    def regex_or(patterns) -> str:
         return '({})'.format('|'.join(patterns))
 
     whitespace = r'\s*'

--- a/src/xdoctest/docstr/docscrape_google.py
+++ b/src/xdoctest/docstr/docscrape_google.py
@@ -519,16 +519,16 @@ def parse_google_argblock(
         >>> assert argdict_list[1]['desc'] == 'a description with a newline'
     """
 
-    def named(key, pattern) -> str:
+    def named(key: str, pattern: str) -> str:
         return '(?P<{}>{})'.format(key, pattern)
 
-    def optional(pattern) -> str:
+    def optional(pattern: str) -> str:
         return '({})?'.format(pattern)
 
-    def positive_lookahead(pattern) -> str:
+    def positive_lookahead(pattern: str) -> str:
         return '(?={})'.format(pattern)
 
-    def regex_or(patterns) -> str:
+    def regex_or(patterns: list[str]) -> str:
         return '({})'.format('|'.join(patterns))
 
     whitespace = r'\s*'

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1679,14 +1679,14 @@ class DocTest:
             print('type(out_text) = %r' % (type(out_text),))
             print('out_text = %r' % (out_text,))
 
-    def _color(self, text, color, enabled=None):
+    def _color(self, text : str, color : str, enabled : bool | None = None):
         """conditionally color text based on config and flags"""
         colored = self.config.getvalue('colored', enabled)
         if colored:
             text = utils.color_text(text, color)
         return text
 
-    def _post_run(self, verbose : bool | int | None) -> dict[str, typing.Any]:
+    def _post_run(self, verbose : bool | int) -> dict[str, typing.Any]:
         """
         Returns:
             Dict : summary

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1639,10 +1639,12 @@ class DocTest:
                             new_line = ','.join(tbparts)
 
                             # failed_ctx = '>>> ' + self.failed_part.exec_lines[tb_lineno - 1]
-                            failed_ctx = self.failed_part.orig_lines[
-                                tb_lineno - 1
-                            ]
-                            extra = '    ' + failed_ctx
+                            _orig_lines = self.failed_part.orig_lines
+                            if not _orig_lines:
+                                failed_ctx = _orig_lines[tb_lineno - 1]
+                                extra = '    ' + failed_ctx
+                            else:
+                                extra = ' No lines?! Bug in xdoctest?'
                             line = new_line + extra + '\n'
 
                         # m = '(t{})'.format(i)

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1686,7 +1686,7 @@ class DocTest:
             text = utils.color_text(text, color)
         return text
 
-    def _post_run(self, verbose) -> dict[str, typing.Any]:
+    def _post_run(self, verbose : bool | int | None) -> dict[str, typing.Any]:
         """
         Returns:
             Dict : summary

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1312,7 +1312,7 @@ class DocTest:
     def _block_prefix(self):
         return 'ZERO-ARG' if self.block_type == 'zero-arg' else 'DOCTEST'
 
-    def _pre_run(self, verbose) -> None:
+    def _pre_run(self, verbose : bool | int) -> None:
         if verbose >= 1:
             if verbose >= 2:
                 barrier = self._color('====== <exec> ======', 'white')
@@ -1516,7 +1516,7 @@ class DocTest:
         # source_text = utils.indent(source_text)
         # lines += source_text.splitlines()
 
-        def r1_strip_nl(text):
+        def r1_strip_nl(text: str | None) -> str | None:
             if text is None:
                 return None
             return text[:-1] if text.endswith('\n') else text

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -53,7 +53,7 @@ class DoctestConfig(dict):
     RuntimeState.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(DoctestConfig, self).__init__(*args, **kwargs)
         self.update(
             {
@@ -396,7 +396,7 @@ class DocTest:
         fpath: str | os.PathLike | None = None,
         block_type: str | None = None,
         mode: str = 'pytest',
-    ):
+    ) -> None:
         """
         Args:
             docsrc (str): the text of the doctest
@@ -593,7 +593,7 @@ class DocTest:
         want: bool = True,
         offset_linenos: bool | None = None,
         prefix: bool = True,
-    ):
+    ) -> None:
         """
         Used by :func:`format_src`
 
@@ -756,7 +756,7 @@ class DocTest:
         for partno, part in enumerate(self._parts):
             part.partno = partno
 
-    def _import_module(self):
+    def _import_module(self) -> None:
         """
         After this point we are in dynamic analysis mode, in most cases
         xdoctest should have been in static-analysis-only mode.
@@ -1311,7 +1311,7 @@ class DocTest:
     def _block_prefix(self):
         return 'ZERO-ARG' if self.block_type == 'zero-arg' else 'DOCTEST'
 
-    def _pre_run(self, verbose):
+    def _pre_run(self, verbose) -> None:
         if verbose >= 1:
             if verbose >= 2:
                 barrier = self._color('====== <exec> ======', 'white')
@@ -1590,7 +1590,7 @@ class DocTest:
                 # where the error occurred in the doctest
                 tblines = traceback.format_exception(*self.exc_info)
 
-                def _alter_traceback_linenos(self, tblines):
+                def _alter_traceback_linenos(self, tblines) -> None:
                     def overwrite_lineno(linepart):
                         # Replace the trailing part which is the lineno
                         old_linestr = linepart[-1]  # noqa
@@ -1666,7 +1666,7 @@ class DocTest:
         lines += ['    ' + self.cmdline]
         return lines
 
-    def _print_captured(self):
+    def _print_captured(self) -> None:
         assert self.logged_stdout is not None
         out_text = ''.join([v for v in self.logged_stdout.values() if v])
         if out_text is not None:
@@ -1732,7 +1732,7 @@ class DocTest:
         return summary
 
 
-def _traverse_traceback(tb):
+def _traverse_traceback(tb) -> None:
     # Lives down here to avoid issue calling exec in a function that contains a
     # nested function with free variable.  Not sure how necessary this is
     # because this doesn't have free variables.

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -39,11 +39,6 @@ TODO:
 """
 
 
-__docstubs__ = """
-from xdoctest.doctest_part import DoctestPart
-"""
-
-
 class DoctestConfig(dict):
     """
     Doctest configuration
@@ -1793,7 +1788,6 @@ class DocTest:
                             tbparts[-2] = ' '.join(linepart)
                             new_line = ','.join(tbparts)
 
-                            # IMPORTANT:
                             # We now fetch the context line from the part that actually owns the
                             # traceback frame, not from `self.failed_part`.
                             #
@@ -1807,72 +1801,7 @@ class DocTest:
 
                     return new_tblines
 
-                # # old buggy _alter_traceback_linenos, remove once we fix the
-                # issue
-                # def _alter_traceback_linenos(self, tblines: list[str]) -> list[str]:
-                #     def overwrite_lineno(linepart: list[str]) -> list[str]:
-                #         # Replace the trailing part which is the lineno
-                #         old_linestr = linepart[-1]  # noqa
-
-                #         # This is the lineno we will insert
-                #         rel_lineno = self.failed_part.line_offset + tb_lineno
-                #         abs_lineno = self.lineno + rel_lineno - 1
-
-                #         new_linestr = 'rel: {rel}, abs: {abs}'.format(
-                #             rel=rel_lineno,
-                #             abs=abs_lineno,
-                #         )
-
-                #         linepart = linepart[:-1] + [new_linestr]
-                #         return linepart
-
-                #     new_tblines = []
-                #     for i, line in enumerate(tblines):
-                #         # if '<frozen importlib._bootstrap' in line:
-                #         #     # not sure if this should be removed or not
-                #         #     continue
-
-                #         if 0:
-                #             # Not a robust acheck
-                #             if 'xdoctest/xdoctest/doctest_example' in line:
-                #                 # hack, remove ourselves from the tracback
-                #                 continue
-                #                 # new_tblines.append('!!!!!')
-                #                 # raise Exception('foo')
-                #                 # continue
-
-                #         if (
-                #             self._partfilename is not None
-                #             and self._partfilename in line
-                #         ):
-                #             # Intercept the line corresponding to the doctest
-                #             tbparts = line.split(',')
-                #             tb_lineno = int(tbparts[-2].strip().split()[1])
-                #             # modify the line number to match the doctest
-                #             linepart = tbparts[-2].split(' ')
-
-                #             linepart = overwrite_lineno(linepart)
-
-                #             tbparts[-2] = ' '.join(linepart)
-                #             new_line = ','.join(tbparts)
-
-                #             # failed_ctx = '>>> ' + self.failed_part.exec_lines[tb_lineno - 1]
-                #             _orig_lines = self.failed_part.orig_lines
-                #             if not _orig_lines:
-                #                 failed_ctx = _orig_lines[tb_lineno - 1]
-                #                 extra = '    ' + failed_ctx
-                #             else:
-                #                 extra = ' No lines?! Bug in xdoctest?'
-                #             line = new_line + extra + '\n'
-
-                #         # m = '(t{})'.format(i)
-                #         # line = m + line.replace('\n', '\n' + m)
-                #         new_tblines.append(line)
-
-                #     return new_tblines
-
                 new_tblines = _alter_traceback_linenos(self, tblines)
-                # new_tblines = tblines
 
                 if colored:
                     tbtext = '\n'.join(new_tblines)

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -16,8 +16,7 @@ import typing
 import warnings
 from collections import OrderedDict
 from inspect import CO_COROUTINE
-from typing import TYPE_CHECKING
-from typing import Any, cast, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from xdoctest import (
     checker,
@@ -54,7 +53,7 @@ class DoctestConfig(dict):
     RuntimeState.
     """
 
-    def __init__(self, *args : Any, **kwargs : Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(DoctestConfig, self).__init__(*args, **kwargs)
         self.update(
             {
@@ -110,7 +109,6 @@ class DoctestConfig(dict):
             add_argument (callable): the parser.add_argument function
         """
         import argparse
-        from typing import Any
 
         def str_lower(x: str) -> str:
             # python2 fix
@@ -922,7 +920,9 @@ class DocTest:
         Returns:
             Dict : summary
         """
-        on_error = cast(Union[str, None], self.config.getvalue('on_error', on_error))
+        on_error = cast(
+            Union[str, None], self.config.getvalue('on_error', on_error)
+        )
         verbose = cast(int, self.config.getvalue('verbose', verbose))
         assert isinstance(verbose, int)
         if on_error not in {'raise', 'return'}:
@@ -1295,7 +1295,9 @@ class DocTest:
                     found_sub_tb = None
                     for sub_tb in _traverse_traceback(tb):
                         tb_filename = sub_tb.tb_frame.f_code.co_filename
-                        tb_part = self._partfilename_to_part.get(tb_filename, None)
+                        tb_part = self._partfilename_to_part.get(
+                            tb_filename, None
+                        )
                         if tb_part is not None:
                             # Walk up the traceback until we find the one that
                             # has the doctest as the base filename
@@ -1307,16 +1309,30 @@ class DocTest:
                         # The only traceback remaining should be
                         # the part that is relevant to the user
                         print('<DEBUG: best sub_tb>', file=sys.stderr)
-                        print('found_lineno = {!r}'.format(found_lineno), file=sys.stderr)
-                        print('found_tb_part = {!r}'.format(found_tb_part), file=sys.stderr)
-                        print(''.join(traceback.format_tb(sub_tb)), file=sys.stderr)
+                        print(
+                            'found_lineno = {!r}'.format(found_lineno),
+                            file=sys.stderr,
+                        )
+                        print(
+                            'found_tb_part = {!r}'.format(found_tb_part),
+                            file=sys.stderr,
+                        )
+                        print(
+                            ''.join(traceback.format_tb(sub_tb)),
+                            file=sys.stderr,
+                        )
                         if found_sub_tb is not None:
-                            print(''.join(traceback.format_tb(found_sub_tb)), file=sys.stderr)
+                            print(
+                                ''.join(traceback.format_tb(found_sub_tb)),
+                                file=sys.stderr,
+                            )
                         print('</DEBUG>', file=sys.stderr)
 
                     if found_lineno is None:
                         if DEBUG:
-                            print('UNABLE TO CLEAN TRACEBACK. EXIT DUE TO DEBUG')
+                            print(
+                                'UNABLE TO CLEAN TRACEBACK. EXIT DUE TO DEBUG'
+                            )
                             sys.exit(1)
                         raise ValueError(
                             f'Could not clean traceback: ex = {_ex_dbg!r}'
@@ -1396,7 +1412,7 @@ class DocTest:
     def _block_prefix(self):
         return 'ZERO-ARG' if self.block_type == 'zero-arg' else 'DOCTEST'
 
-    def _pre_run(self, verbose : bool | int) -> None:
+    def _pre_run(self, verbose: bool | int) -> None:
         if verbose >= 1:
             if verbose >= 2:
                 barrier = self._color('====== <exec> ======', 'white')
@@ -1684,9 +1700,14 @@ class DocTest:
                 # where the error occurred in the doctest
                 tblines = traceback.format_exception(*self.exc_info)
 
-                def _alter_traceback_linenos(self, tblines: list[str]) -> list[str]:
-                    def overwrite_lineno(linepart: list[str], tb_part: 'DoctestPart', tb_lineno: int) -> list[str]:
-
+                def _alter_traceback_linenos(
+                    self, tblines: list[str]
+                ) -> list[str]:
+                    def overwrite_lineno(
+                        linepart: list[str],
+                        tb_part: 'DoctestPart',
+                        tb_lineno: int,
+                    ) -> list[str]:
                         """
                         Rewrite the displayed traceback line number so it
                         refers to the user's doctest line numbers instead of
@@ -1704,7 +1725,9 @@ class DocTest:
                         linepart = linepart[:-1] + [new_linestr]
                         return linepart
 
-                    def lookup_tb_part(line) -> tuple[None, None] | tuple[str, 'DoctestPart']:
+                    def lookup_tb_part(
+                        line,
+                    ) -> tuple[None, None] | tuple[str, 'DoctestPart']:
                         """
                         Given a traceback text line, find which synthetic
                         per-part filename it refers to and then recover the
@@ -1715,13 +1738,13 @@ class DocTest:
                         ever be a substring of another.
                         """
                         _fname_to_part: dict[str, 'DoctestPart'] = (
-                            self._partfilename_to_part)
+                            self._partfilename_to_part
+                        )
                         if not _fname_to_part:
                             return None, None
 
                         partfilename_list: list[str] = sorted(
-                            _fname_to_part.keys(), key=str.__len__,
-                            reverse=True
+                            _fname_to_part.keys(), key=str.__len__, reverse=True
                         )
                         for partfilename in partfilename_list:
                             if partfilename in line:
@@ -1743,7 +1766,9 @@ class DocTest:
                         ownership, and only then use a small, defensive
                         fallback to `exec_lines` if needed.
                         """
-                        ctx_lines = tb_part.orig_lines or tb_part.exec_lines or []
+                        ctx_lines = (
+                            tb_part.orig_lines or tb_part.exec_lines or []
+                        )
                         if 1 <= tb_lineno <= len(ctx_lines):
                             return ctx_lines[tb_lineno - 1]
                         return ''
@@ -1762,7 +1787,9 @@ class DocTest:
                             tb_lineno = int(tbparts[-2].strip().split()[1])
 
                             linepart = tbparts[-2].split(' ')
-                            linepart = overwrite_lineno(linepart, tb_part, tb_lineno)
+                            linepart = overwrite_lineno(
+                                linepart, tb_part, tb_lineno
+                            )
                             tbparts[-2] = ' '.join(linepart)
                             new_line = ','.join(tbparts)
 
@@ -1872,14 +1899,14 @@ class DocTest:
             print('type(out_text) = %r' % (type(out_text),))
             print('out_text = %r' % (out_text,))
 
-    def _color(self, text : str, color : str, enabled : bool | None = None):
+    def _color(self, text: str, color: str, enabled: bool | None = None):
         """conditionally color text based on config and flags"""
         colored = self.config.getvalue('colored', enabled)
         if colored:
             text = utils.color_text(text, color)
         return text
 
-    def _post_run(self, verbose : bool | int) -> dict[str, typing.Any]:
+    def _post_run(self, verbose: bool | int) -> dict[str, typing.Any]:
         """
         Returns:
             Dict : summary

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -387,6 +387,16 @@ class DocTest:
     _runstate: typing.Any
     global_namespace: dict[str, typing.Any]
 
+    # This is the doctest *part* that actually owns the traceback frame we
+    # chose as the "interesting" frame for reporting. This is important for
+    # doctests that define functions and fail in those functions.
+    failed_tb_part: 'DoctestPart' | None
+
+    # Internally we give each doctest part a synthetic file, this maps the name
+    # back to the actual doctest part so we can correctly report traceback
+    # frames in error reports
+    _partfilename_to_part: dict[str, 'DoctestPart']
+
     def __init__(
         self,
         docsrc: str,
@@ -452,6 +462,15 @@ class DocTest:
         self.warn_list = None
 
         self._partfilename = None
+
+        # stores the specific doctest part that owns the traceback frame that
+        # we selected as the "user relevant" frame.
+        self.failed_tb_part = None
+        # Map synthetic per-part filenames back to the corresponding
+        # DoctestPart.  This lets traceback rewriting recover the correct
+        # source context even when a later part calls code defined in an
+        # earlier part.
+        self._partfilename_to_part = {}
 
         self.logged_evals = OrderedDict()
         self.logged_stdout = OrderedDict()
@@ -866,6 +885,21 @@ class DocTest:
         compileflags |= ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
         return test_globals, compileflags
 
+    def _partfilename_for(self, partno: int) -> str:
+        """
+        Construct a synthetic filename for a specific doctest part.
+
+        We can't use one filename for the entire doctest because traceback
+        frames only record a filename + line number. If every compiled part
+        shares the same filename, then when a traceback points into code
+        defined in an earlier part, we cannot tell which part that line number
+        belongs to.
+
+        Giving each part its own pseudo-filename makes traceback ownership
+        unambiguous.
+        """
+        return f'<doctest:{self.node}:part{partno}>'
+
     def anything_ran(self) -> bool:
         """
         Returns:
@@ -907,6 +941,14 @@ class DocTest:
         self._skipped_parts = []
         self.exc_info = None
         self._suppressed_stdout = verbose <= 1
+
+        # Reset traceback bookkeeping from any prior run.
+        self.failed_tb_lineno = None
+        self.failed_tb_part = None
+
+        # Reset the synthetic filename bookkeeping for this run.
+        self._partfilename = None
+        self._partfilename_to_part = {}
 
         # Initialize a new runtime state
         default_state = self.config['default_runtime_state']
@@ -1034,12 +1076,32 @@ class DocTest:
                     did_pre_import = True
 
                 try:
+                    # Give every doctest part its own synthetic filename.
+                    #
+                    # This matters because the traceback only tells us
+                    # "filename X, line Y".
+                    #
+                    # Before this patch, every part in the doctest used the
+                    # same filename, so when an exception happened inside a
+                    # function defined earlier and called later, the traceback
+                    # line number was ambiguous. xdoctest would later assume
+                    # the traceback belonged to `self.failed_part`, which is
+                    # often just the *calling* part, not the part that
+                    # originally defined the code frame.
+                    #
+                    # By using a unique filename per part, traceback frames can
+                    # be mapped back to the exact DoctestPart that owns them.
+                    self._partfilename = self._partfilename_for(partx)
+
+                    # Record the owning part so traceback rewriting can recover
+                    # the correct part from the synthetic filename later.
+                    self._partfilename_to_part[self._partfilename] = part
+
+                    source_text = part.compilable_source()
+
                     # Compile code, handle syntax errors
                     #   part.compile_mode can be single, exec, or eval.
                     #   Typically single is used instead of eval
-                    self._partfilename = f'<doctest:{self.node}>'
-                    source_text = part.compilable_source()
-
                     code = compile(
                         source_text,
                         mode=part.compile_mode,
@@ -1212,40 +1274,62 @@ class DocTest:
                     # doctest, and remove the parts that point to
                     # boilerplate lines in this file.
                     found_lineno = None
+                    found_tb_part = None
+
+                    # Walk the traceback looking for the first frame that came
+                    # from one of our synthetic doctest-part filenames.
+                    #
+                    # We intentionally do NOT compare only against
+                    # `self._partfilename` here.
+                    #
+                    # `self._partfilename` is just the filename of the part we
+                    # most recently compiled / executed. But the traceback may
+                    # point into code defined in an *earlier* part, for example
+                    # a function or class method defined earlier and invoked by
+                    # the current part.
+                    #
+                    # Therefore we resolve traceback ownership against the full
+                    # `_partfilename_to_part` map for this run.
+                    found_lineno = None
+                    found_tb_part = None
+                    found_sub_tb = None
                     for sub_tb in _traverse_traceback(tb):
                         tb_filename = sub_tb.tb_frame.f_code.co_filename
-                        if tb_filename == self._partfilename:
-                            # Walk up the traceback until we find the one that has
-                            # the doctest as the base filename
+                        tb_part = self._partfilename_to_part.get(tb_filename, None)
+                        if tb_part is not None:
+                            # Walk up the traceback until we find the one that
+                            # has the doctest as the base filename
                             found_lineno = sub_tb.tb_lineno
-                            break
+                            found_tb_part = tb_part
+                            found_sub_tb = sub_tb
+
                     if DEBUG:
                         # The only traceback remaining should be
                         # the part that is relevant to the user
                         print('<DEBUG: best sub_tb>', file=sys.stderr)
-                        print(
-                            'found_lineno = {!r}'.format(found_lineno),
-                            file=sys.stderr,
-                        )
-                        print(
-                            ''.join(traceback.format_tb(sub_tb)),
-                            file=sys.stderr,
-                        )
+                        print('found_lineno = {!r}'.format(found_lineno), file=sys.stderr)
+                        print('found_tb_part = {!r}'.format(found_tb_part), file=sys.stderr)
+                        print(''.join(traceback.format_tb(sub_tb)), file=sys.stderr)
+                        if found_sub_tb is not None:
+                            print(''.join(traceback.format_tb(found_sub_tb)), file=sys.stderr)
                         print('</DEBUG>', file=sys.stderr)
 
                     if found_lineno is None:
                         if DEBUG:
-                            print(
-                                'UNABLE TO CLEAN TRACEBACK. EXIT DUE TO DEBUG'
-                            )
+                            print('UNABLE TO CLEAN TRACEBACK. EXIT DUE TO DEBUG')
                             sys.exit(1)
                         raise ValueError(
-                            'Could not clean traceback: ex = {!r}'.format(
-                                _ex_dbg
-                            )
+                            f'Could not clean traceback: ex = {_ex_dbg!r}'
                         )
                     else:
+                        # Store both the traceback-relative line number and the
+                        # part that owns that traceback frame.
+                        #
+                        # Storing only the line number is not enough; later
+                        # formatting code also needs to know which part's
+                        # `orig_lines` or `exec_lines` should be used.
                         self.failed_tb_lineno = found_lineno
+                        self.failed_tb_part = found_tb_part
 
                     self.exc_info = _exec_info
 
@@ -1335,19 +1419,17 @@ class DocTest:
     def failed_line_offset(self) -> int | None:
         """
         Determine which line in the doctest failed.
-
-        Returns:
-            int | None
         """
         if self.exc_info is None:
             return None
         else:
             if self.failed_part == '<IMPORT>':
                 return 0
+
             ex_type, ex_value, tb = self.exc_info
             assert self.failed_part is not None
             assert not isinstance(self.failed_part, str)
-            offset = self.failed_part.line_offset
+
             if isinstance(
                 ex_value,
                 (
@@ -1355,14 +1437,25 @@ class DocTest:
                     exceptions.ExistingEventLoopError,
                 ),
             ):
-                # Return the line of the "got" expression
+                # These exceptions conceptually belong to the currently failed
+                # part, not some nested traceback frame in earlier code.
+                offset = self.failed_part.line_offset
                 offset += self.failed_part.n_exec_lines
+
             elif isinstance(ex_value, checker.GotWantException):
-                # Return the line of the want line
+                # Same idea here: got/want failures are about the currently
+                # failed part's want block.
+                offset = self.failed_part.line_offset
                 offset += self.failed_part.n_exec_lines + 1
+
             else:
+                # For ordinary execution exceptions, the relevant line may be
+                # inside code defined by an earlier doctest part.
                 assert self.failed_tb_lineno is not None
+                tb_part = self.failed_tb_part or self.failed_part
+                offset = tb_part.line_offset
                 offset += self.failed_tb_lineno
+
             offset -= 1
             return offset
 
@@ -1592,66 +1685,164 @@ class DocTest:
                 tblines = traceback.format_exception(*self.exc_info)
 
                 def _alter_traceback_linenos(self, tblines: list[str]) -> list[str]:
-                    def overwrite_lineno(linepart: list[str]) -> list[str]:
-                        # Replace the trailing part which is the lineno
-                        old_linestr = linepart[-1]  # noqa
+                    def overwrite_lineno(linepart: list[str], tb_part: 'DoctestPart', tb_lineno: int) -> list[str]:
 
-                        # This is the lineno we will insert
-                        rel_lineno = self.failed_part.line_offset + tb_lineno
+                        """
+                        Rewrite the displayed traceback line number so it
+                        refers to the user's doctest line numbers instead of
+                        the synthetic per-part filename's local line numbers.
+
+                        `tb_lineno` is local to `tb_part`.
+                        We convert it to:
+                            - `rel_lineno`: line relative to the full doctest
+                            - `abs_lineno`: line relative to the original source file
+                        """
+                        rel_lineno = tb_part.line_offset + tb_lineno
                         abs_lineno = self.lineno + rel_lineno - 1
 
-                        new_linestr = 'rel: {rel}, abs: {abs}'.format(
-                            rel=rel_lineno,
-                            abs=abs_lineno,
-                        )
-
+                        new_linestr = f'rel: {rel_lineno}, abs: {abs_lineno}'
                         linepart = linepart[:-1] + [new_linestr]
                         return linepart
 
+                    def lookup_tb_part(line) -> tuple[None, None] | tuple[str, 'DoctestPart']:
+                        """
+                        Given a traceback text line, find which synthetic
+                        per-part filename it refers to and then recover the
+                        owning DoctestPart.
+
+                        We sort by descending filename length as a small
+                        robustness measure in case one synthetic filename could
+                        ever be a substring of another.
+                        """
+                        _fname_to_part: dict[str, 'DoctestPart'] = (
+                            self._partfilename_to_part)
+                        if not _fname_to_part:
+                            return None, None
+
+                        partfilename_list: list[str] = sorted(
+                            _fname_to_part.keys(), key=str.__len__,
+                            reverse=True
+                        )
+                        for partfilename in partfilename_list:
+                            if partfilename in line:
+                                part = self._partfilename_to_part[partfilename]
+                                return partfilename, part
+
+                        return None, None
+
+                    def lookup_ctx_line(tb_part, tb_lineno):
+                        """
+                        Recover the source context line to append after the
+                        traceback frame.
+
+                        `orig_lines` is formatter-oriented and may not always
+                        be present.  It is nice when available because it
+                        preserves the original doctest prompt formatting.
+
+                        `orig_lines`. Compared to previous versions this fixes
+                        ownership, and only then use a small, defensive
+                        fallback to `exec_lines` if needed.
+                        """
+                        ctx_lines = tb_part.orig_lines or tb_part.exec_lines or []
+                        if 1 <= tb_lineno <= len(ctx_lines):
+                            return ctx_lines[tb_lineno - 1]
+                        return ''
+
                     new_tblines = []
                     for i, line in enumerate(tblines):
-                        # if '<frozen importlib._bootstrap' in line:
-                        #     # not sure if this should be removed or not
-                        #     continue
+                        matched_filename, tb_part = lookup_tb_part(line)
 
-                        if 0:
-                            # Not a robust acheck
-                            if 'xdoctest/xdoctest/doctest_example' in line:
-                                # hack, remove ourselves from the tracback
-                                continue
-                                # new_tblines.append('!!!!!')
-                                # raise Exception('foo')
-                                # continue
-
-                        if (
-                            self._partfilename is not None
-                            and self._partfilename in line
-                        ):
-                            # Intercept the line corresponding to the doctest
+                        if matched_filename is not None and tb_part is not None:
+                            # Example input line shape:
+                            #   File "<doctest:...:part0>", line 2, in foo
+                            #
+                            # We parse the local traceback line number, then rewrite it to
+                            # doctest-relative / source-relative numbers.
                             tbparts = line.split(',')
                             tb_lineno = int(tbparts[-2].strip().split()[1])
-                            # modify the line number to match the doctest
+
                             linepart = tbparts[-2].split(' ')
-
-                            linepart = overwrite_lineno(linepart)
-
+                            linepart = overwrite_lineno(linepart, tb_part, tb_lineno)
                             tbparts[-2] = ' '.join(linepart)
                             new_line = ','.join(tbparts)
 
-                            # failed_ctx = '>>> ' + self.failed_part.exec_lines[tb_lineno - 1]
-                            _orig_lines = self.failed_part.orig_lines
-                            if not _orig_lines:
-                                failed_ctx = _orig_lines[tb_lineno - 1]
-                                extra = '    ' + failed_ctx
-                            else:
-                                extra = ' No lines?! Bug in xdoctest?'
+                            # IMPORTANT:
+                            # We now fetch the context line from the part that actually owns the
+                            # traceback frame, not from `self.failed_part`.
+                            #
+                            # This is the direct fix for the IndexError class of bugs that occur
+                            # when the traceback points into an earlier definition part.
+                            failed_ctx = lookup_ctx_line(tb_part, tb_lineno)
+                            extra = ('    ' + failed_ctx) if failed_ctx else ''
                             line = new_line + extra + '\n'
 
-                        # m = '(t{})'.format(i)
-                        # line = m + line.replace('\n', '\n' + m)
                         new_tblines.append(line)
 
                     return new_tblines
+
+                # # old buggy _alter_traceback_linenos, remove once we fix the
+                # issue
+                # def _alter_traceback_linenos(self, tblines: list[str]) -> list[str]:
+                #     def overwrite_lineno(linepart: list[str]) -> list[str]:
+                #         # Replace the trailing part which is the lineno
+                #         old_linestr = linepart[-1]  # noqa
+
+                #         # This is the lineno we will insert
+                #         rel_lineno = self.failed_part.line_offset + tb_lineno
+                #         abs_lineno = self.lineno + rel_lineno - 1
+
+                #         new_linestr = 'rel: {rel}, abs: {abs}'.format(
+                #             rel=rel_lineno,
+                #             abs=abs_lineno,
+                #         )
+
+                #         linepart = linepart[:-1] + [new_linestr]
+                #         return linepart
+
+                #     new_tblines = []
+                #     for i, line in enumerate(tblines):
+                #         # if '<frozen importlib._bootstrap' in line:
+                #         #     # not sure if this should be removed or not
+                #         #     continue
+
+                #         if 0:
+                #             # Not a robust acheck
+                #             if 'xdoctest/xdoctest/doctest_example' in line:
+                #                 # hack, remove ourselves from the tracback
+                #                 continue
+                #                 # new_tblines.append('!!!!!')
+                #                 # raise Exception('foo')
+                #                 # continue
+
+                #         if (
+                #             self._partfilename is not None
+                #             and self._partfilename in line
+                #         ):
+                #             # Intercept the line corresponding to the doctest
+                #             tbparts = line.split(',')
+                #             tb_lineno = int(tbparts[-2].strip().split()[1])
+                #             # modify the line number to match the doctest
+                #             linepart = tbparts[-2].split(' ')
+
+                #             linepart = overwrite_lineno(linepart)
+
+                #             tbparts[-2] = ' '.join(linepart)
+                #             new_line = ','.join(tbparts)
+
+                #             # failed_ctx = '>>> ' + self.failed_part.exec_lines[tb_lineno - 1]
+                #             _orig_lines = self.failed_part.orig_lines
+                #             if not _orig_lines:
+                #                 failed_ctx = _orig_lines[tb_lineno - 1]
+                #                 extra = '    ' + failed_ctx
+                #             else:
+                #                 extra = ' No lines?! Bug in xdoctest?'
+                #             line = new_line + extra + '\n'
+
+                #         # m = '(t{})'.format(i)
+                #         # line = m + line.replace('\n', '\n' + m)
+                #         new_tblines.append(line)
+
+                #     return new_tblines
 
                 new_tblines = _alter_traceback_linenos(self, tblines)
                 # new_tblines = tblines

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -17,6 +17,7 @@ import warnings
 from collections import OrderedDict
 from inspect import CO_COROUTINE
 from typing import TYPE_CHECKING
+from typing import Any, cast, Union
 
 from xdoctest import (
     checker,
@@ -53,7 +54,7 @@ class DoctestConfig(dict):
     RuntimeState.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args : Any, **kwargs : Any) -> None:
         super(DoctestConfig, self).__init__(*args, **kwargs)
         self.update(
             {
@@ -593,7 +594,7 @@ class DocTest:
         want: bool = True,
         offset_linenos: bool | None = None,
         prefix: bool = True,
-    ) -> None:
+    ):
         """
         Used by :func:`format_src`
 
@@ -813,7 +814,7 @@ class DocTest:
                         )
 
     @staticmethod
-    def _extract_future_flags(namespace) -> int:
+    def _extract_future_flags(namespace: typing.Mapping) -> int:
         """
         Return the compiler-flags associated with the future features that
         have been imported into the given namespace (i.e. globals).
@@ -875,7 +876,7 @@ class DocTest:
         return len(self.logged_stdout) > 0
 
     def run(
-        self, verbose: typing.Any = None, on_error: typing.Any = None
+        self, verbose: int | None | bool = None, on_error: str | None = None
     ) -> dict[str, typing.Any]:
         """
         Executes the doctest, checks the results, reports the outcome.
@@ -887,8 +888,8 @@ class DocTest:
         Returns:
             Dict : summary
         """
-        on_error = self.config.getvalue('on_error', on_error)
-        verbose = self.config.getvalue('verbose', verbose)
+        on_error = cast(Union[str, None], self.config.getvalue('on_error', on_error))
+        verbose = cast(int, self.config.getvalue('verbose', verbose))
         assert isinstance(verbose, int)
         if on_error not in {'raise', 'return'}:
             raise KeyError(on_error)
@@ -1590,8 +1591,8 @@ class DocTest:
                 # where the error occurred in the doctest
                 tblines = traceback.format_exception(*self.exc_info)
 
-                def _alter_traceback_linenos(self, tblines) -> None:
-                    def overwrite_lineno(linepart):
+                def _alter_traceback_linenos(self, tblines: list[str]) -> list[str]:
+                    def overwrite_lineno(linepart: list[str]) -> list[str]:
                         # Replace the trailing part which is the lineno
                         old_linestr = linepart[-1]  # noqa
 
@@ -1732,7 +1733,7 @@ class DocTest:
         return summary
 
 
-def _traverse_traceback(tb) -> None:
+def _traverse_traceback(tb):
     # Lives down here to avoid issue calling exec in a function that contains a
     # nested function with free variable.  Not sure how necessary this is
     # because this doesn't have free variables.

--- a/src/xdoctest/doctest_part.py
+++ b/src/xdoctest/doctest_part.py
@@ -191,12 +191,12 @@ class DoctestPart:
             parts.append('want="%s..."' % (head_wnt,))
         return ', '.join(parts)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         classname = self.__class__.__name__
         devnice = self.__nice__()
         return '<%s(%s) at %s>' % (classname, devnice, hex(id(self)))
 
-    def __str__(self):
+    def __str__(self) -> str:
         classname = self.__class__.__name__
         devnice = self.__nice__()
         return '<%s(%s)>' % (classname, devnice)

--- a/src/xdoctest/doctest_part.py
+++ b/src/xdoctest/doctest_part.py
@@ -176,6 +176,7 @@ class DoctestPart:
         """
         parts = []
         if self.line_offset is not None:
+            # Note: dead code if we enforce current types
             parts.append('ln %s' % (self.line_offset))
         if self.source:
             head_src = self.source.splitlines()[0][0:8]

--- a/src/xdoctest/dynamic_analysis.py
+++ b/src/xdoctest/dynamic_analysis.py
@@ -198,7 +198,7 @@ def iter_module_doctestables(
         property,
     )
 
-    def _recurse(item, module):
+    def _recurse(item: typing.Any, module: typing.Any) -> bool:
         return is_defined_by_module(item, module)
 
     for key, val in module.__dict__.items():
@@ -229,7 +229,7 @@ def iter_module_doctestables(
                     yield key + '.' + subkey, item
 
 
-def is_defined_by_module(item: typing.Any, module: typing.Any):
+def is_defined_by_module(item: typing.Any, module: typing.Any) -> bool:
     """
     Check if item is directly defined by a module.
 

--- a/src/xdoctest/exceptions.py
+++ b/src/xdoctest/exceptions.py
@@ -57,7 +57,7 @@ class IncompleteParseError(SyntaxError):
     """
 
 
-def _resolve_skipped_exception_class():
+def _resolve_skipped_exception_class() -> typing.Any:
     try:
         from _pytest.outcomes import Skipped as pytest_skipped
     except ImportError:  # nocover

--- a/src/xdoctest/exceptions.py
+++ b/src/xdoctest/exceptions.py
@@ -32,7 +32,7 @@ class DoctestParseError(Exception):
         string: str | None = None,
         info: typing.Any | None = None,
         orig_ex: Exception | None = None,
-    ):
+    ) -> None:
         """
         Args:
             msg (str): error message

--- a/src/xdoctest/parser.py
+++ b/src/xdoctest/parser.py
@@ -48,6 +48,7 @@ import ast
 import re
 import sys
 import tokenize
+import typing
 
 from xdoctest import directive, doctest_part, exceptions, global_state, utils
 from xdoctest import static_analysis as static
@@ -547,12 +548,12 @@ class DoctestParser:
         # Strip indentation (and PS1 / PS2 from source)
         exec_source_lines = [p[4:] for p in source_lines]
 
-        def _hack_comment_statements(lines):
+        def _hack_comment_statements(lines) -> typing.Iterable[str]:
             # Hack to make comments appear like executable statements
             # note, this hack never leaves this function because we only are
             # returning line numbers.
             # FIXME: there is probably a better way to do this.
-            def balanced_intervals(lines: list[str]):
+            def balanced_intervals(lines: list[str]) -> list[tuple[int, int]]:
                 """
                 Finds intervals of balanced nesting syntax
 
@@ -659,7 +660,7 @@ class DoctestParser:
             ps1_linenos = []
             for node in statement_nodes:
                 if hasattr(node, 'decorator_list') and node.decorator_list:
-                    lineno = node.decorator_list[0].lineno - 1
+                    lineno = node.decorator_list[0].lineno - 1  # type: ignore
                 else:
                     lineno = node.lineno - 1
                 ps1_linenos.append(lineno)
@@ -698,7 +699,7 @@ class DoctestParser:
             # TODO: we probably could just save the tokens if we got them earlier?
             iterable = (line for line in exec_source_lines if line)
 
-            def _readline():
+            def _readline() -> str:
                 return next(iterable)
 
             # We cannot eval a statement with a semicolon in it

--- a/src/xdoctest/parser.py
+++ b/src/xdoctest/parser.py
@@ -234,7 +234,7 @@ class DoctestParser:
             print('\n===== FINISHED PARSE ====')
         return all_parts
 
-    def _package_groups(self, grouped_lines):
+    def _package_groups(self, grouped_lines) -> None:
         if global_state.DEBUG_PARSER > 1:
             import ubelt as ub
 
@@ -254,7 +254,7 @@ class DoctestParser:
         if global_state.DEBUG_PARSER > 1:
             print('</PACKAGE LABEL GROUPS>')
 
-    def _package_chunk(self, raw_source_lines, raw_want_lines, lineno=0):
+    def _package_chunk(self, raw_source_lines, raw_want_lines, lineno=0) -> None:
         """
         if `self.simulate_repl` is True, then each statement is broken into its
         own part.  Otherwise, statements are grouped by the closest `want`
@@ -903,7 +903,7 @@ def _min_indentation(s):
         return 0
 
 
-def _complete_source(line, state_indent, line_iter):
+def _complete_source(line, state_indent, line_iter) -> None:
     """
     helper
     remove lines from the iterator if they are needed to complete source

--- a/src/xdoctest/parser.py
+++ b/src/xdoctest/parser.py
@@ -320,7 +320,7 @@ class DoctestParser:
         if global_state.DEBUG_PARSER > 3:
             print(f'break_linenos={break_linenos}')
 
-        def slice_example(s1, s2, want_lines=None):
+        def slice_example(s1, s2, want_lines=None) -> doctest_part.DoctestPart:
             exec_lines = exec_source_lines[s1:s2]
             orig_lines = source_lines[s1:s2]
             directives = ps1_to_directive.get(s1, None)
@@ -1061,7 +1061,7 @@ def _iterthree(items, pad_value=None):
         yield left, mid, right
 
 
-def _hasprefix(line, prefixes):
+def _hasprefix(line, prefixes) -> bool:
     """helper prefix test"""
     # if not isinstance(prefixes, tuple):
     #     prefixes = [prefixes]

--- a/src/xdoctest/parser.py
+++ b/src/xdoctest/parser.py
@@ -587,7 +587,7 @@ class DoctestParser:
             interval_starts = {t[0] for t in intervals}
 
             def _indent(line: str) -> str:
-                return line[:len(line) - len(line.lstrip())]
+                return line[: len(line) - len(line.lstrip())]
 
             def _infer_comment_indent(idx: int, line: str) -> str:
                 """Infer the indentation a placeholder comment statement

--- a/src/xdoctest/parser.py
+++ b/src/xdoctest/parser.py
@@ -234,7 +234,7 @@ class DoctestParser:
             print('\n===== FINISHED PARSE ====')
         return all_parts
 
-    def _package_groups(self, grouped_lines) -> None:
+    def _package_groups(self, grouped_lines):
         if global_state.DEBUG_PARSER > 1:
             import ubelt as ub
 
@@ -254,7 +254,7 @@ class DoctestParser:
         if global_state.DEBUG_PARSER > 1:
             print('</PACKAGE LABEL GROUPS>')
 
-    def _package_chunk(self, raw_source_lines, raw_want_lines, lineno=0) -> None:
+    def _package_chunk(self, raw_source_lines, raw_want_lines, lineno=0):
         """
         if `self.simulate_repl` is True, then each statement is broken into its
         own part.  Otherwise, statements are grouped by the closest `want`
@@ -903,7 +903,7 @@ def _min_indentation(s):
         return 0
 
 
-def _complete_source(line, state_indent, line_iter) -> None:
+def _complete_source(line, state_indent, line_iter):
     """
     helper
     remove lines from the iterator if they are needed to complete source

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -303,11 +303,11 @@ class XDoctestItem(pytest.Item):
             self.dtest.globs.update(globs)
         else:
             if self.dtest is not None:
-                self.fixture_request = _setup_fixtures(self)
+                self.fixture_request = _setup_fixtures(self)  # type: ignore
                 global_namespace = dict(
-                    getfixture=self.fixture_request.getfixturevalue
+                    getfixture=self.fixture_request.getfixturevalue  # type: ignore
                 )
-                for name, value in self.fixture_request.getfixturevalue(
+                for name, value in self.fixture_request.getfixturevalue(  # type: ignore
                     'xdoctest_namespace'
                 ).items():
                     global_namespace[name] = value

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -81,7 +81,7 @@ import xdoctest.doctest_example
 """
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     manager = config.pluginmanager
     all_plugins = {
         manager.get_name(plugin): plugin for plugin in manager.get_plugins()
@@ -92,7 +92,7 @@ def pytest_configure(config):
             manager.unregister(all_plugins[incompatible])
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     # TODO: make this programmatically mirror the argparse in __main__
     from xdoctest import core
 
@@ -219,7 +219,7 @@ def _is_xdoctest(config, path, parent):
 
 
 class ReprFailXDoctest(code.TerminalRepr):
-    def __init__(self, reprlocation: typing.Any, lines: list[str]):
+    def __init__(self, reprlocation: typing.Any, lines: list[str]) -> None:
         """
         Args:
             reprlocation (Any):
@@ -229,7 +229,7 @@ class ReprFailXDoctest(code.TerminalRepr):
         self.reprlocation = reprlocation
         self.lines = lines
 
-    def toterminal(self, tw):
+    def toterminal(self, tw) -> None:
         for line in self.lines:
             tw.line(line)
         self.reprlocation.toterminal(tw)
@@ -242,7 +242,7 @@ class XDoctestItem(pytest.Item):
         parent: typing.Any,
         runner: typing.Any = None,
         dtest: typing.Any = None,
-    ):
+    ) -> None:
         """
         Args:
             name (str):
@@ -292,7 +292,7 @@ class XDoctestItem(pytest.Item):
         self.funcargs: Dict[str, object] = {}
         self._request = TopRequest(cast(Any, self), _ispytest=True)
 
-    def setup(self):
+    def setup(self) -> None:
         if _PYTEST_IS_GE_800:
             self._request._fillfixtures()
             globs = dict(getfixture=self._request.getfixturevalue)
@@ -313,7 +313,7 @@ class XDoctestItem(pytest.Item):
                     global_namespace[name] = value
                 self.dtest.global_namespace.update(global_namespace)
 
-    def runtest(self):
+    def runtest(self) -> None:
         if self.dtest.is_disabled(pytest=True):
             pytest.skip('doctest encountered global skip directive')
         # verbose = self.dtest.config['verbose']
@@ -350,9 +350,9 @@ class XDoctestItem(pytest.Item):
 
 
 class _XDoctestBase(pytest.Module):
-    def _prepare_internal_config(self):
+    def _prepare_internal_config(self) -> None:
         class NamespaceLike:
-            def __init__(self, config):
+            def __init__(self, config) -> None:
                 self.config = config
 
             def __getitem__(self, attr):
@@ -405,7 +405,7 @@ class XDoctestTextfile(_XDoctestBase):
 
 
 class XDoctestModule(_XDoctestBase):
-    def collect(self):
+    def collect(self) -> None:
         from xdoctest import core
 
         modpath = str(self.fspath)
@@ -445,7 +445,7 @@ def _setup_fixtures(xdoctest_item: XDoctestItem) -> fixtures.FixtureRequest:
         fixtures.FixtureRequest
     """
 
-    def func():
+    def func() -> None:
         pass
 
     xdoctest_item.funcargs = {}

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -76,10 +76,6 @@ _INCOMPATIBLE_PLUGINS = frozenset({'doctest'})
 #     with open(fpath, 'a') as file:
 #         file.write(str(text) + '\n')
 
-__docstubs__ = """
-import xdoctest.doctest_example
-"""
-
 
 def pytest_configure(config) -> None:
     manager = config.pluginmanager

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -405,7 +405,7 @@ class XDoctestTextfile(_XDoctestBase):
 
 
 class XDoctestModule(_XDoctestBase):
-    def collect(self) -> None:
+    def collect(self):
         from xdoctest import core
 
         modpath = str(self.fspath)

--- a/src/xdoctest/runner.py
+++ b/src/xdoctest/runner.py
@@ -558,6 +558,10 @@ def undefined_names(sourcecode: str) -> set[str]:
     import pyflakes.reporter
 
     class CaptureReporter(pyflakes.reporter.Reporter):
+        syntax_errors: list[str]
+        messages: list[typing.Any]
+        unexpected: list[str]
+
         def __init__(reporter, warningStream, errorStream) -> None:
             reporter.syntax_errors = []
             reporter.messages = []
@@ -910,7 +914,7 @@ def _update_argparse_cli(add_argument, prefix=None) -> None:
         help=('Same as if durations=0'),
     )
 
-    add_argument_kws = [
+    add_argument_kws: list[tuple[list, dict]] = [
         # (['--style'], dict(dest='style',
         #                    type=str, help='choose your style',
         #                    choices=['auto', 'google', 'freeform'], default='auto')),

--- a/src/xdoctest/runner.py
+++ b/src/xdoctest/runner.py
@@ -67,7 +67,7 @@ from xdoctest import (
 )
 
 
-def log(msg: str, verbose: bool | int, level: int = 1):
+def log(msg: str, verbose: bool | int, level: int = 1) -> None:
     """
     Simple conditional print logger
 
@@ -81,7 +81,7 @@ def log(msg: str, verbose: bool | int, level: int = 1):
         print(msg)
 
 
-def doctest_callable(func: Callable[..., typing.Any]):
+def doctest_callable(func: Callable[..., typing.Any]) -> None:
     """
     Executes doctests an in-memory function or class.
 
@@ -119,7 +119,7 @@ def doctest_callable(func: Callable[..., typing.Any]):
 
 def gather_doctests(
     doctest_identifiers, style='auto', analysis='auto', verbose=None
-):
+) -> None:
     raise NotImplementedError('todo')
 
 
@@ -399,7 +399,7 @@ def doctest_module(
     return run_summary
 
 
-def _auto_disable_failing_tests_hook(context):
+def _auto_disable_failing_tests_hook(context) -> None:
     """
     Experimental feature to modify code based on failing tests.
     This should likely be moved to its own submodule.
@@ -554,18 +554,18 @@ def undefined_names(sourcecode: str) -> set[str]:
     import pyflakes.reporter
 
     class CaptureReporter(pyflakes.reporter.Reporter):
-        def __init__(reporter, warningStream, errorStream):
+        def __init__(reporter, warningStream, errorStream) -> None:
             reporter.syntax_errors = []
             reporter.messages = []
             reporter.unexpected = []
 
-        def unexpectedError(reporter, filename, msg):
+        def unexpectedError(reporter, filename, msg) -> None:
             reporter.unexpected.append(msg)
 
-        def syntaxError(reporter, filename, msg, lineno, offset, text):
+        def syntaxError(reporter, filename, msg, lineno, offset, text) -> None:
             reporter.syntax_errors.append(msg)
 
-        def flake(reporter, message):
+        def flake(reporter, message) -> None:
             reporter.messages.append(message)
 
     names = set()
@@ -587,13 +587,13 @@ def _print_summary_report(
     durations,
     config=None,
     _log=None,
-):
+) -> None:
     """
     Summary report formatting and printing
     """
     assert _log is not None
 
-    def cprint(text, color):
+    def cprint(text, color) -> None:
         if config is not None and config.get('colored', True):
             _log(utils.color_text(text, color))
         else:
@@ -698,7 +698,7 @@ def _print_summary_report(
             _log('time: {:0.8f}, test: {}'.format(n_secs, example.cmdline))
 
 
-def _gather_zero_arg_examples(modpath):
+def _gather_zero_arg_examples(modpath) -> None:
     """
     Find functions in `modpath` args  with no args (so we can automatically
     make a dummy docstring).
@@ -846,7 +846,7 @@ def _parse_commandline(command=None, style='auto', verbose=None, argv=None):
     return command, style, verbose
 
 
-def _update_argparse_cli(add_argument, prefix=None):
+def _update_argparse_cli(add_argument, prefix=None) -> None:
     """
     Update the CLI with arguments that control how doctests are collected ando
     how aggregate results are reported.

--- a/src/xdoctest/runner.py
+++ b/src/xdoctest/runner.py
@@ -291,7 +291,7 @@ def doctest_module(
 
     # Parse all valid examples
     with warnings.catch_warnings(record=True) as parse_warnlist:
-        examples = list(
+        examples : list[doctest_example.DocTest] = list(
             core.parse_doctestables(
                 parsable_identifier,
                 exclude=exclude,
@@ -443,7 +443,7 @@ def _auto_disable_failing_tests_hook(context) -> None:
             file.write(''.join(lines))
 
 
-def _convert_to_test_module(enabled_examples):
+def _convert_to_test_module(enabled_examples: list[doctest_example.DocTest]) -> str:
     """
     Logic for the "dumps" command.
 
@@ -456,6 +456,7 @@ def _convert_to_test_module(enabled_examples):
 
     module_lines = []
     for example in enabled_examples:
+        assert example.modname is not None
         # Create a unit-testable function for this example
         func_name = (
             'test_'
@@ -479,6 +480,7 @@ def _convert_to_test_module(enabled_examples):
             global_lines = example.config['global_exec'].split('\\n')
             header_lines.extend([g + '  # NOQA' for g in global_lines])
 
+        assert example._parts is not None
         for part in example._parts:
             if dump_config['remove_import_star']:
                 new_exec_lines = []

--- a/src/xdoctest/runner.py
+++ b/src/xdoctest/runner.py
@@ -698,7 +698,7 @@ def _print_summary_report(
             _log('time: {:0.8f}, test: {}'.format(n_secs, example.cmdline))
 
 
-def _gather_zero_arg_examples(modpath) -> None:
+def _gather_zero_arg_examples(modpath):
     """
     Find functions in `modpath` args  with no args (so we can automatically
     make a dummy docstring).

--- a/src/xdoctest/runner.py
+++ b/src/xdoctest/runner.py
@@ -291,7 +291,7 @@ def doctest_module(
 
     # Parse all valid examples
     with warnings.catch_warnings(record=True) as parse_warnlist:
-        examples : list[doctest_example.DocTest] = list(
+        examples: list[doctest_example.DocTest] = list(
             core.parse_doctestables(
                 parsable_identifier,
                 exclude=exclude,
@@ -443,7 +443,9 @@ def _auto_disable_failing_tests_hook(context) -> None:
             file.write(''.join(lines))
 
 
-def _convert_to_test_module(enabled_examples: list[doctest_example.DocTest]) -> str:
+def _convert_to_test_module(
+    enabled_examples: list[doctest_example.DocTest],
+) -> str:
     """
     Logic for the "dumps" command.
 

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -47,10 +47,10 @@ class CallDefNode:
     def __init__(
         self,
         callname: str,
-        lineno: int,
-        docstr: str,
-        doclineno: int,
-        doclineno_end: int,
+        lineno: int | None,
+        docstr: str | None,
+        doclineno: int | None,
+        doclineno_end: int | None,
         args: ast.arguments | None = None,
     ) -> None:
         """
@@ -146,7 +146,7 @@ class TopLevelVisitor(ast.NodeVisitor):
     """
 
     @classmethod
-    def parse(cls, source: str):
+    def parse(cls, source: str) -> TopLevelVisitor:
         """
         main entry point
 
@@ -221,7 +221,7 @@ class TopLevelVisitor(ast.NodeVisitor):
 
     def _visit_generic_FunctionDef(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef
-    ):
+    ) -> None:
         if self._current_classname is None:
             callname = node.name
         else:
@@ -253,14 +253,14 @@ class TopLevelVisitor(ast.NodeVisitor):
 
         self._finish_queue.append(calldef)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef):
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         """
         Args:
             node (ast.FunctionDef):
         """
         return self._visit_generic_FunctionDef(node)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         """
         Args:
             node (ast.AsyncFunctionDef):
@@ -321,7 +321,7 @@ class TopLevelVisitor(ast.NodeVisitor):
             # self.const_lookup
         self.generic_visit(node)
 
-    def visit_If(self, node: ast.If):
+    def visit_If(self, node: ast.If) -> None:
         """
         Args:
             node (ast.If):
@@ -370,7 +370,7 @@ class TopLevelVisitor(ast.NodeVisitor):
 
     # -- helpers ---
 
-    def _docnode_line_workaround(self, docnode: ast.Expr) -> tuple[int, int]:
+    def _docnode_line_workaround(self, docnode: ast.Expr | ast.stmt) -> tuple[int, int]:
         """
         Find the start and ending line numbers of a docstring
 
@@ -443,6 +443,7 @@ class TopLevelVisitor(ast.NodeVisitor):
                 else:
                     docstr = utils.ensure_unicode(docnode.value.s)  # type: ignore[attr-defined]
                 sourcelines = self.sourcelines
+                assert sourcelines is not None
                 start, stop = self._find_docstr_endpos_workaround(
                     docstr, sourcelines, startpos
                 )
@@ -471,7 +472,9 @@ class TopLevelVisitor(ast.NodeVisitor):
         return doclineno, doclineno_end
 
     @classmethod
-    def _find_docstr_endpos_workaround(cls, docstr, sourcelines, startpos):
+    def _find_docstr_endpos_workaround(
+        cls, docstr: str, sourcelines: list[str], startpos: int
+    ) -> tuple[int, int]:
         """
         Like docstr_line_workaround, but works from the top-down instead of
         bottom-up. This is for pypy.
@@ -688,7 +691,9 @@ class TopLevelVisitor(ast.NodeVisitor):
                     start = stop - 1
         return start, stop
 
-    def _get_docstring(self, node):
+    def _get_docstring(
+        self, node: ast.AST | ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module
+    ) -> tuple[str | None, int | None, int | None]:
         """
         CommandLine:
             xdoctest -m xdoctest.static_analysis.py TopLevelVisitor._get_docstring
@@ -704,6 +709,7 @@ class TopLevelVisitor(ast.NodeVisitor):
             >>> self._get_docstring(node)
             ('docstr', 2, 2)
         """
+        assert isinstance(node, (ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module))
         docstr = ast.get_docstring(node, clean=False)
         if docstr is not None:
             docnode = node.body[0]
@@ -760,7 +766,9 @@ def parse_static_calldefs(
         raise
 
 
-def parse_calldefs(source=None, fpath=None):
+def parse_calldefs(
+    source: str | None = None, fpath: str | os.PathLike | None = None
+) -> dict[str, CallDefNode]:
     from xdoctest.utils import util_deprecation
 
     util_deprecation.schedule_deprecation(
@@ -775,7 +783,7 @@ def parse_calldefs(source=None, fpath=None):
     return parse_static_calldefs(source=source, fpath=fpath)
 
 
-def _parse_static_node_value(node):
+def _parse_static_node_value(node: ast.AST) -> typing.Any:
     """
     Extract a constant value from a node if possible
     """
@@ -789,6 +797,7 @@ def _parse_static_node_value(node):
 
     import numbers
 
+    value: typing.Any = None
     if isinstance(node, ast.Constant) and isinstance(
         node.value, numbers.Number
     ):
@@ -806,8 +815,8 @@ def _parse_static_node_value(node):
             value = list(elts)
     # Handle mapping-like nodes
     elif hasattr(node, 'keys') and hasattr(node, 'values'):
-        keys = list(map(_parse_static_node_value, node.keys))
-        values = list(map(_parse_static_node_value, node.values))
+        keys = list(map(_parse_static_node_value, node.keys))  # type: ignore
+        values = list(map(_parse_static_node_value, node.values))  # type: ignore
         value = OrderedDict(zip(keys, values))
     # Avoid direct reference to ast.NameConstant which is deprecated in
     # Python 3.14; access it via getattr so linters won't emit a deprecation
@@ -818,6 +827,7 @@ def _parse_static_node_value(node):
         and NameConstant is not None
         and isinstance(node, NameConstant)
     ):
+        assert hasattr(node, 'value')
         value = node.value
     elif isinstance(node, ast.Constant):
         value = node.value
@@ -876,7 +886,7 @@ def parse_static_value(
     pt = ast.parse(source)
 
     class AssignentVisitor(ast.NodeVisitor):
-        def visit_Assign(self, node) -> None:
+        def visit_Assign(self, node: ast.Assign) -> None:
             for target in node.targets:
                 target_id = getattr(target, 'id', None)
                 if target_id == key:
@@ -1048,7 +1058,7 @@ def is_balanced_statement(
     lines = list(lines)
     iterable = (line for line in lines if line)
 
-    def _readline():
+    def _readline() -> str:
         return next(iterable)
 
     try:
@@ -1090,7 +1100,7 @@ def is_balanced_statement(
         return True
 
 
-def extract_comments(source: str | list[str]) -> None:
+def extract_comments(source: str | list[str]) -> typing.Iterator[str]:
     """
     Returns the text in each comment in a block of python code.
     Uses tokenize to account for quotations.
@@ -1122,7 +1132,7 @@ def extract_comments(source: str | list[str]) -> None:
     # Only iterate through non-empty lines otherwise tokenize will stop short
     iterable = (line for line in lines if line)
 
-    def _readline():
+    def _readline() -> str:
         return next(iterable)
 
     try:
@@ -1131,9 +1141,10 @@ def extract_comments(source: str | list[str]) -> None:
                 yield t[1]
     except tokenize.TokenError:
         pass
+    return None
 
 
-def _strip_hashtag_comments_and_newlines(source: str | list[str]) -> None:
+def _strip_hashtag_comments_and_newlines(source: str | list[str]) -> str:
     """
     Removes hashtag comments from underlying source
 
@@ -1183,13 +1194,15 @@ def _strip_hashtag_comments_and_newlines(source: str | list[str]) -> None:
     else:
         readline = iter(source).__next__
 
-    def strip_hashtag_comments(tokens):
+    def strip_hashtag_comments(tokens: typing.Iterator[tuple]) -> typing.Iterator[tuple]:
         """
         Drop comment tokens from a `tokenize` stream.
         """
         return (t for t in tokens if t[0] != tokenize.COMMENT)
 
-    def strip_consecutive_newlines(tokens) -> None:
+    def strip_consecutive_newlines(
+        tokens: typing.Iterator[tuple]
+    ) -> typing.Iterator[tuple]:
         """
         Consecutive newlines are dropped and trailing whitespace
 

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -26,9 +26,9 @@ from typing import Union
 PLAT_IMPL = platform.python_implementation()
 
 
-IS_PY_GE_312 = sys.version_info[0:2] >= (3, 12)
-IS_PY_GE_308 = sys.version_info[0:2] >= (3, 8)  # type: bool
-IS_PY_LT_314 = sys.version_info[0:2] < (3, 14)  # type: bool
+IS_PY_GE_312 : bool = sys.version_info[0:2] >= (3, 12)
+IS_PY_GE_308 : bool = sys.version_info[0:2] >= (3, 8) 
+IS_PY_LT_314 : bool = sys.version_info[0:2] < (3, 14)  
 
 
 if IS_PY_GE_312:
@@ -36,6 +36,12 @@ if IS_PY_GE_312:
 else:
     tokenize = importlib.import_module('tokenize')
 
+DocNode = typing.Union[
+    ast.AsyncFunctionDef,
+    ast.FunctionDef,
+    ast.ClassDef,
+    ast.Module,
+]
 
 class CallDefNode:
     """
@@ -692,7 +698,7 @@ class TopLevelVisitor(ast.NodeVisitor):
         return start, stop
 
     def _get_docstring(
-        self, node: ast.AST | ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module
+        self, node: DocNode
     ) -> tuple[str | None, int | None, int | None]:
         """
         CommandLine:
@@ -709,11 +715,9 @@ class TopLevelVisitor(ast.NodeVisitor):
             >>> self._get_docstring(node)
             ('docstr', 2, 2)
         """
-        if typing.TYPE_CHECKING:
-            assert isinstance(node, (Union[ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef, ast.Module]))
         docstr = ast.get_docstring(node, clean=False)
         if docstr is not None:
-            docnode = node.body[0]
+            docnode = node.body[0]  # type: ignore
             doclineno, doclineno_end = self._docnode_line_workaround(docnode)
         else:
             doclineno = None

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -448,9 +448,9 @@ class TopLevelVisitor(ast.NodeVisitor):
             if PLAT_IMPL == 'PyPy':
                 startpos = docnode.lineno - 1
                 if IS_PY_GE_312:
-                    docstr = utils.ensure_unicode(docnode.value.value)  # type: ignore[attr-defined]
+                    docstr = utils.ensure_unicode(docnode.value.value)  # type: ignore
                 else:
-                    docstr = utils.ensure_unicode(docnode.value.s)  # type: ignore[attr-defined]
+                    docstr = utils.ensure_unicode(docnode.value.s)  # type: ignore
                 sourcelines = self.sourcelines
                 assert sourcelines is not None
                 start, stop = self._find_docstr_endpos_workaround(

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -22,13 +22,13 @@ from xdoctest.utils.util_import import (  # NOQA
     modpath_to_modname,
     split_modpath,
 )
-from typing import Union
+
 PLAT_IMPL = platform.python_implementation()
 
 
-IS_PY_GE_312 : bool = sys.version_info[0:2] >= (3, 12)
-IS_PY_GE_308 : bool = sys.version_info[0:2] >= (3, 8) 
-IS_PY_LT_314 : bool = sys.version_info[0:2] < (3, 14)  
+IS_PY_GE_312: bool = sys.version_info[0:2] >= (3, 12)
+IS_PY_GE_308: bool = sys.version_info[0:2] >= (3, 8)
+IS_PY_LT_314: bool = sys.version_info[0:2] < (3, 14)
 
 
 if IS_PY_GE_312:
@@ -42,6 +42,7 @@ DocNode = typing.Union[
     ast.ClassDef,
     ast.Module,
 ]
+
 
 class CallDefNode:
     """
@@ -376,7 +377,9 @@ class TopLevelVisitor(ast.NodeVisitor):
 
     # -- helpers ---
 
-    def _docnode_line_workaround(self, docnode: ast.Expr | ast.stmt) -> tuple[int, int]:
+    def _docnode_line_workaround(
+        self, docnode: ast.Expr | ast.stmt
+    ) -> tuple[int, int]:
         """
         Find the start and ending line numbers of a docstring
 
@@ -1199,14 +1202,16 @@ def _strip_hashtag_comments_and_newlines(source: str | list[str]) -> str:
     else:
         readline = iter(source).__next__
 
-    def strip_hashtag_comments(tokens: typing.Iterator[tuple]) -> typing.Iterator[tuple]:
+    def strip_hashtag_comments(
+        tokens: typing.Iterator[tuple],
+    ) -> typing.Iterator[tuple]:
         """
         Drop comment tokens from a `tokenize` stream.
         """
         return (t for t in tokens if t[0] != tokenize.COMMENT)
 
     def strip_consecutive_newlines(
-        tokens: typing.Iterator[tuple]
+        tokens: typing.Iterator[tuple],
     ) -> typing.Iterator[tuple]:
         """
         Consecutive newlines are dropped and trailing whitespace

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -22,7 +22,7 @@ from xdoctest.utils.util_import import (  # NOQA
     modpath_to_modname,
     split_modpath,
 )
-
+from typing import Union
 PLAT_IMPL = platform.python_implementation()
 
 
@@ -709,7 +709,8 @@ class TopLevelVisitor(ast.NodeVisitor):
             >>> self._get_docstring(node)
             ('docstr', 2, 2)
         """
-        assert isinstance(node, (ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module))
+        if typing.TYPE_CHECKING:
+            assert isinstance(node, (Union[ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef, ast.Module]))
         docstr = ast.get_docstring(node, clean=False)
         if docstr is not None:
             docnode = node.body[0]

--- a/src/xdoctest/static_analysis.py
+++ b/src/xdoctest/static_analysis.py
@@ -52,7 +52,7 @@ class CallDefNode:
         doclineno: int,
         doclineno_end: int,
         args: ast.arguments | None = None,
-    ):
+    ) -> None:
         """
         Args:
             callname (str):
@@ -164,7 +164,7 @@ class TopLevelVisitor(ast.NodeVisitor):
         self.process_finished(lineno_end)
         return self
 
-    def __init__(self, source: str | None = None):
+    def __init__(self, source: str | None = None) -> None:
         """
         Args:
             source (None | str):
@@ -194,7 +194,7 @@ class TopLevelVisitor(ast.NodeVisitor):
         pt = ast.parse(self.source)
         return pt
 
-    def process_finished(self, node: ast.AST | int):
+    def process_finished(self, node: ast.AST | int) -> None:
         """
         process (get ending lineno) for everything marked as finished
 
@@ -211,7 +211,7 @@ class TopLevelVisitor(ast.NodeVisitor):
                 calldef = self._finish_queue.pop()
                 calldef.lineno_end = lineno_end
 
-    def visit(self, node: ast.AST):
+    def visit(self, node: ast.AST) -> None:
         """
         Args:
             node (ast.AST):
@@ -267,7 +267,7 @@ class TopLevelVisitor(ast.NodeVisitor):
         """
         return self._visit_generic_FunctionDef(node)
 
-    def visit_ClassDef(self, node: ast.ClassDef):
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
         """
         Args:
             node (ast.ClassDef):
@@ -286,7 +286,7 @@ class TopLevelVisitor(ast.NodeVisitor):
 
             self._finish_queue.append(calldef)
 
-    def visit_Module(self, node: ast.Module):
+    def visit_Module(self, node: ast.Module) -> None:
         """
         Args:
             node (ast.Module):
@@ -305,7 +305,7 @@ class TopLevelVisitor(ast.NodeVisitor):
         self.generic_visit(node)
         # self._finish_queue.append(calldef)
 
-    def visit_Assign(self, node: ast.Assign):
+    def visit_Assign(self, node: ast.Assign) -> None:
         """
         Args:
             node (ast.Assign):
@@ -876,7 +876,7 @@ def parse_static_value(
     pt = ast.parse(source)
 
     class AssignentVisitor(ast.NodeVisitor):
-        def visit_Assign(self, node):
+        def visit_Assign(self, node) -> None:
             for target in node.targets:
                 target_id = getattr(target, 'id', None)
                 if target_id == key:
@@ -1090,7 +1090,7 @@ def is_balanced_statement(
         return True
 
 
-def extract_comments(source: str | list[str]):
+def extract_comments(source: str | list[str]) -> None:
     """
     Returns the text in each comment in a block of python code.
     Uses tokenize to account for quotations.
@@ -1133,7 +1133,7 @@ def extract_comments(source: str | list[str]):
         pass
 
 
-def _strip_hashtag_comments_and_newlines(source: str | list[str]):
+def _strip_hashtag_comments_and_newlines(source: str | list[str]) -> None:
     """
     Removes hashtag comments from underlying source
 
@@ -1189,7 +1189,7 @@ def _strip_hashtag_comments_and_newlines(source: str | list[str]):
         """
         return (t for t in tokens if t[0] != tokenize.COMMENT)
 
-    def strip_consecutive_newlines(tokens):
+    def strip_consecutive_newlines(tokens) -> None:
         """
         Consecutive newlines are dropped and trailing whitespace
 

--- a/src/xdoctest/utils/util_asyncio.py
+++ b/src/xdoctest/utils/util_asyncio.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import typing
 
 
 # see asyncio.runners.Runner
@@ -13,9 +14,9 @@ class FallbackRunner:
     """A fallback implementation of :class:`asyncio.Runner` for Python<3.11."""
 
     def __init__(self) -> None:
-        self._loop = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
-    def run(self, coro):
+    def run(self, coro: typing.Any) -> typing.Any:
         """
         Run code in the embedded event loop.
 

--- a/src/xdoctest/utils/util_import.py
+++ b/src/xdoctest/utils/util_import.py
@@ -623,13 +623,13 @@ def _static_parse(varname: typing.Any, fpath: typing.Any) -> typing.Any:
     pt = ast.parse(sourcecode)
 
     class StaticVisitor(ast.NodeVisitor):
-        def visit_Assign(self, node):
+        def visit_Assign(self, node) -> None:
             for target in node.targets:
                 target_id = getattr(target, 'id', None)
                 if target_id == varname:
                     self.static_value = _parse_static_node_value(node.value)
 
-        def visit_AnnAssign(self, node):
+        def visit_AnnAssign(self, node) -> None:
             target = node.target
             target_id = getattr(target, 'id', None)
             if target_id == varname:

--- a/src/xdoctest/utils/util_import.py
+++ b/src/xdoctest/utils/util_import.py
@@ -59,7 +59,9 @@ def is_modname_importable(
     return flag
 
 
-def _importlib_import_modpath(modpath: str | os.PathLike) -> ModuleType:  # nocover
+def _importlib_import_modpath(
+    modpath: str | os.PathLike,
+) -> ModuleType:  # nocover
     """
     Alternative to import_module_from_path using importlib mechainsms
 
@@ -246,7 +248,9 @@ class PythonPathContext:
             sys.path.pop(self.index)
 
 
-def _custom_import_modpath(modpath: str | os.PathLike, index: int = -1) -> ModuleType:
+def _custom_import_modpath(
+    modpath: str | os.PathLike, index: int = -1
+) -> ModuleType:
     dpath, rel_modpath = split_modpath(modpath)
     modname = modpath_to_modname(modpath)
     try:

--- a/src/xdoctest/utils/util_import.py
+++ b/src/xdoctest/utils/util_import.py
@@ -59,7 +59,7 @@ def is_modname_importable(
     return flag
 
 
-def _importlib_import_modpath(modpath: typing.Any):  # nocover
+def _importlib_import_modpath(modpath: str | os.PathLike) -> ModuleType:  # nocover
     """
     Alternative to import_module_from_path using importlib mechainsms
 
@@ -78,7 +78,7 @@ def _importlib_import_modpath(modpath: typing.Any):  # nocover
     return module
 
 
-def _importlib_modname_to_modpath(modname: typing.Any):  # nocover
+def _importlib_modname_to_modpath(modname: str) -> str:  # nocover
     """
     faster version of :func:`_syspath_modname_to_modpath` using builtin
     python mechanisms, but unfortunately it doesn't play nice with pytest.
@@ -246,7 +246,7 @@ class PythonPathContext:
             sys.path.pop(self.index)
 
 
-def _custom_import_modpath(modpath, index=-1):
+def _custom_import_modpath(modpath: str | os.PathLike, index: int = -1) -> ModuleType:
     dpath, rel_modpath = split_modpath(modpath)
     modname = modpath_to_modname(modpath)
     try:
@@ -510,7 +510,7 @@ IS_PY_LT_314: bool = sys.version_info[0:2] < (3, 14)
 IS_PY_GE_308: bool = sys.version_info[0:2] >= (3, 8)
 
 
-def _parse_static_node_value(node):
+def _parse_static_node_value(node: typing.Any) -> typing.Any:
     """
     Extract a constant value from a node if possible
     """
@@ -623,13 +623,13 @@ def _static_parse(varname: typing.Any, fpath: typing.Any) -> typing.Any:
     pt = ast.parse(sourcecode)
 
     class StaticVisitor(ast.NodeVisitor):
-        def visit_Assign(self, node) -> None:
+        def visit_Assign(self, node: ast.Assign) -> None:
             for target in node.targets:
                 target_id = getattr(target, 'id', None)
                 if target_id == varname:
                     self.static_value = _parse_static_node_value(node.value)
 
-        def visit_AnnAssign(self, node) -> None:
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
             target = node.target
             target_id = getattr(target, 'id', None)
             if target_id == varname:
@@ -732,7 +732,7 @@ def _syspath_modname_to_modpath(
     """
     import glob
 
-    def _isvalid(modpath, base):
+    def _isvalid(modpath: str, base: str) -> bool:
         # every directory up to the module, should have an init
         subdir = dirname(modpath)
         while subdir and subdir != base:
@@ -758,7 +758,7 @@ def _syspath_modname_to_modpath(
 
     if exclude:
 
-        def normalize(p):
+        def normalize(p: str) -> str:
             if sys.platform.startswith('win32'):  # nocover
                 return realpath(p).lower()
             else:
@@ -770,7 +770,7 @@ def _syspath_modname_to_modpath(
             p for p in candidate_dpaths if normalize(p) not in real_exclude
         ]
 
-    def check_dpath(dpath):
+    def check_dpath(dpath: str) -> str | None:
         # Check for directory-based modules (has precedence over files)
         modpath = join(dpath, _fname_we)
         if exists(modpath):
@@ -784,6 +784,8 @@ def _syspath_modname_to_modpath(
             if isfile(modpath):
                 if _isvalid(modpath, dpath):
                     return modpath
+
+        return None
 
     _pkg_name = _fname_we.split(os.path.sep)[0]
     _pkg_name_hypen = _pkg_name.replace('_', '-')

--- a/src/xdoctest/utils/util_misc.py
+++ b/src/xdoctest/utils/util_misc.py
@@ -100,7 +100,7 @@ def _run_case(source: str, style: str = 'auto') -> str | None:
 
     COLOR = 'yellow'
 
-    def cprint(msg, color=COLOR):
+    def cprint(msg, color=COLOR) -> None:
         print(utils.color_text(str(msg), COLOR))
 
     cprint('\n\n\n <RUN CASE> \n  ========  \n', COLOR)

--- a/src/xdoctest/utils/util_misc.py
+++ b/src/xdoctest/utils/util_misc.py
@@ -100,7 +100,7 @@ def _run_case(source: str, style: str = 'auto') -> str | None:
 
     COLOR = 'yellow'
 
-    def cprint(msg, color=COLOR) -> None:
+    def cprint(msg: str, color: str = COLOR) -> None:
         print(utils.color_text(str(msg), COLOR))
 
     cprint('\n\n\n <RUN CASE> \n  ========  \n', COLOR)

--- a/src/xdoctest/utils/util_mixins.py
+++ b/src/xdoctest/utils/util_mixins.py
@@ -3,6 +3,7 @@ Port of NiceRepr from ubelt.util_mixins
 """
 
 from __future__ import annotations
+
 import warnings
 
 

--- a/src/xdoctest/utils/util_notebook.py
+++ b/src/xdoctest/utils/util_notebook.py
@@ -170,7 +170,10 @@ class NotebookLoader:
                 # run the code in the module
                 codeobj = compile(
                     typing.cast(
-                        typing.Union[ast.Module, ast.Expression, ast.Interactive], tree
+                        typing.Union[
+                            ast.Module, ast.Expression, ast.Interactive
+                        ],
+                        tree,
                     ),
                     filename=fpath,
                     mode='exec',

--- a/src/xdoctest/utils/util_notebook.py
+++ b/src/xdoctest/utils/util_notebook.py
@@ -301,7 +301,9 @@ def execute_notebook(
     return nb, resources
 
 
-def _make_test_notebook_fpath(fpath: typing.Any, cell_sources: typing.Any) -> typing.Any:
+def _make_test_notebook_fpath(
+    fpath: typing.Any, cell_sources: typing.Any
+) -> typing.Any:
     """
     Helper for testing
 

--- a/src/xdoctest/utils/util_notebook.py
+++ b/src/xdoctest/utils/util_notebook.py
@@ -301,7 +301,7 @@ def execute_notebook(
     return nb, resources
 
 
-def _make_test_notebook_fpath(fpath: typing.Any, cell_sources: typing.Any):
+def _make_test_notebook_fpath(fpath: typing.Any, cell_sources: typing.Any) -> typing.Any:
     """
     Helper for testing
 

--- a/src/xdoctest/utils/util_notebook.py
+++ b/src/xdoctest/utils/util_notebook.py
@@ -105,7 +105,7 @@ class NotebookLoader:
         'encoding': 'utf-8',
     }
 
-    def __init__(self, path=None):
+    def __init__(self, path=None) -> None:
         from IPython.core.interactiveshell import InteractiveShell
 
         self.shell = InteractiveShell.instance()

--- a/src/xdoctest/utils/util_stream.py
+++ b/src/xdoctest/utils/util_stream.py
@@ -98,7 +98,7 @@ class TeeStringIO(io.StringIO):
             self.redirect.write(msg)
         return super(TeeStringIO, self).write(msg)
 
-    def flush(self):  # nocover
+    def flush(self) -> None:  # nocover
         """
         Flush to this and the redirected stream
         """

--- a/tests/test_binary_ext.py
+++ b/tests/test_binary_ext.py
@@ -95,7 +95,7 @@ cmake ..
 """
 
 
-def build_demo_extmod():
+def build_demo_extmod() -> str:
     """
     CommandLine:
         python tests/test_binary_ext.py build_demo_extmod

--- a/tests/test_binary_ext.py
+++ b/tests/test_binary_ext.py
@@ -182,7 +182,7 @@ def build_demo_extmod():
     return extmod_fpath
 
 
-def test_run_binary_doctests():
+def test_run_binary_doctests() -> None:
     """
     Tests that we can run doctests in a compiled pybind11 module
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -197,9 +197,7 @@ def test_correct_skipping_on_decorators1() -> None:
             file.write(source)
 
         examples = list(
-            core.parse_doctestables(
-                modpath, style='google', analysis='static'
-            )
+            core.parse_doctestables(modpath, style='google', analysis='static')
         )
         print(f'examples={examples}')
 
@@ -247,9 +245,7 @@ def test_correct_skipping_on_decorators_simple() -> None:
             file.write(source)
 
         examples = list(
-            core.parse_doctestables(
-                modpath, style='google', analysis='static'
-            )
+            core.parse_doctestables(modpath, style='google', analysis='static')
         )
         print(f'examples={examples}')
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,8 +1,9 @@
 from xdoctest import utils
+from xdoctest import core
 from xdoctest.utils.util_misc import _run_case
 
 
-def test_properties():
+def test_properties() -> None:
     """
     Test that all doctests are extracted from properties correctly.
     https://github.com/Erotemic/xdoctest/issues/73
@@ -29,6 +30,7 @@ def test_properties():
         '''
         )
     )
+    assert text is not None
     assert 'running 1 test' in text
 
     text = _run_case(
@@ -47,6 +49,7 @@ def test_properties():
         '''
         )
     )
+    assert text is not None
     assert 'running 1 test' in text
 
     text = _run_case(
@@ -74,6 +77,7 @@ def test_properties():
         '''
         )
     )
+    assert text is not None
     assert 'running 1 test' in text
 
     text = _run_case(
@@ -95,6 +99,7 @@ def test_properties():
         '''
         )
     )
+    assert text is not None
     assert 'running 0 test' in text
 
     text = _run_case(
@@ -125,10 +130,11 @@ def test_properties():
         '''
         )
     )
+    assert text is not None
     assert 'running 0 test' in text
 
 
-def test_correct_skipping_on_decorators1():
+def test_correct_skipping_on_decorators1() -> None:
     """
     This is a weird case similar to the torch dispatch doctest
 
@@ -191,7 +197,7 @@ def test_correct_skipping_on_decorators1():
             file.write(source)
 
         examples = list(
-            xdoctest.core.parse_doctestables(
+            core.parse_doctestables(
                 modpath, style='google', analysis='static'
             )
         )
@@ -200,10 +206,11 @@ def test_correct_skipping_on_decorators1():
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'all', argv=[''], config=config)
         print(cap.text)
+        assert cap.text is not None
         assert '1 skipped' in cap.text
 
 
-def test_correct_skipping_on_decorators_simple():
+def test_correct_skipping_on_decorators_simple() -> None:
     """
     minimal test for decorator skips
     """
@@ -240,7 +247,7 @@ def test_correct_skipping_on_decorators_simple():
             file.write(source)
 
         examples = list(
-            xdoctest.core.parse_doctestables(
+            core.parse_doctestables(
                 modpath, style='google', analysis='static'
             )
         )
@@ -249,4 +256,5 @@ def test_correct_skipping_on_decorators_simple():
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'all', argv=[''], config=config)
         print(cap.text)
+        assert cap.text is not None
         assert '1 skipped' in cap.text

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,5 +1,4 @@
-from xdoctest import utils
-from xdoctest import core
+from xdoctest import core, utils
 from xdoctest.utils.util_misc import _run_case
 
 
@@ -151,7 +150,6 @@ def test_correct_skipping_on_decorators1() -> None:
     """
     from os.path import join
 
-    import xdoctest
     from xdoctest import runner
 
     source = utils.codeblock(
@@ -215,7 +213,6 @@ def test_correct_skipping_on_decorators_simple() -> None:
 
     from os.path import join
 
-    import xdoctest
     from xdoctest import runner
 
     source = utils.codeblock(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3,7 +3,7 @@ from xdoctest import checker, directive
 # from xdoctest import utils
 
 
-def test_visible_lines():
+def test_visible_lines() -> None:
     """
     pytest tests/test_checker.py
     """
@@ -13,7 +13,7 @@ def test_visible_lines():
     assert checker.check_output(got, want)
 
 
-def test_visible_lines_explicit():
+def test_visible_lines_explicit() -> None:
     """
     pytest tests/test_checker.py
     """
@@ -24,7 +24,7 @@ def test_visible_lines_explicit():
     assert checker.check_output(got, want)
 
 
-def test_blankline_accept():
+def test_blankline_accept() -> None:
     """
     pytest tests/test_checker.py
     """
@@ -35,7 +35,7 @@ def test_blankline_accept():
     assert checker.check_output(got, want, runstate)
 
 
-def test_blankline_failcase():
+def test_blankline_failcase() -> None:
     # Check that blankline is not normalizd in a "got" statement
     runstate = directive.RuntimeState({'DONT_ACCEPT_BLANKLINE': False})
     got = 'foo\n<BLANKLINE>\nbar'
@@ -43,7 +43,7 @@ def test_blankline_failcase():
     assert not checker.check_output(got, want, runstate)
 
 
-def test_blankline_not_accept():
+def test_blankline_not_accept() -> None:
     # Check that blankline is not normalized away when
     # DONT_ACCEPT_BLANKLINE is on
     runstate = directive.RuntimeState({'DONT_ACCEPT_BLANKLINE': True})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,9 +2,10 @@ from os.path import join
 
 import xdoctest
 from xdoctest import core, utils
+import typing
 
 
-def _test_status(docstr):
+def _test_status(docstr: str) -> dict[str, typing.Any]:
     docstr = utils.codeblock(docstr)
     try:
         temp = utils.util_misc.TempDoctest(docstr=docstr)
@@ -22,7 +23,8 @@ def _test_status(docstr):
         print(inspect.getargspec(utils.TempDoctest))
         raise
     doctests = list(core.parse_doctestables(temp.modpath))
-    status = doctests[0].run(verbose=0, on_error='return')
+    doctest = doctests[0]
+    status = doctest.run(verbose=0, on_error='return')
     return status
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
+import typing
 from os.path import join
 
 import xdoctest
 from xdoctest import core, utils
-import typing
 
 
 def _test_status(docstr: str) -> dict[str, typing.Any]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from os.path import join
 
 import xdoctest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,9 +26,10 @@ def _test_status(docstr):
     return status
 
 
-def test_mod_lineno():
+def test_mod_lineno() -> None:
     with utils.TempDir() as temp:
         dpath = temp.dpath
+        assert dpath is not None
         modpath = join(dpath, 'test_mod_lineno.py')
         source = utils.codeblock(
             '''
@@ -54,15 +55,17 @@ def test_mod_lineno():
         assert self.format_src(offset_linenos=False).strip().startswith('1')
         assert self.format_src(offset_linenos=True).strip().startswith('5')
 
+        assert dpath is not None
         with utils.PythonPathContext(dpath):
             status = self.run(verbose=10, on_error='return')
 
         assert not status['passed']
 
 
-def test_mod_globals():
+def test_mod_globals() -> None:
     with utils.TempDir() as temp:
         dpath = temp.dpath
+        assert dpath is not None
         modpath = join(dpath, 'test_mod_globals.py')
         source = utils.codeblock(
             '''
@@ -82,13 +85,15 @@ def test_mod_globals():
         assert len(doctests) == 1
         self = doctests[0]
 
+        assert dpath is not None
         with utils.PythonPathContext(dpath):
             status = self.run(verbose=0, on_error='return')
         assert status['passed']
+        assert self.logged_evals is not None
         assert self.logged_evals[0] == 10
 
 
-def test_show_entire():
+def test_show_entire() -> None:
     """
     pytest tests/test_core.py::test_show_entire
     """
@@ -135,6 +140,7 @@ def test_show_entire():
     self = doctests[0]
     self.config['colored'] = False
     print(self.lineno)
+    assert self._parts is not None
     print(self._parts[0].line_offset)
     print(self.format_src())
 
@@ -150,7 +156,7 @@ def test_show_entire():
     temp.cleanup()
 
 
-def test_freeform_parse_lineno():
+def test_freeform_parse_lineno() -> None:
     """
     python ~/code/xdoctest/tests/test_core.py test_freeform_parse_lineno
 
@@ -195,6 +201,7 @@ def test_freeform_parse_lineno():
     # This asserts if the lines are consecutive. Should we enforce this?
     # Perhaps its ok if they are not.
     for test in doctests:
+        assert test._parts is not None
         assert test._parts[0].line_offset == 0
         offset = 0
         for p in test._parts:
@@ -211,6 +218,7 @@ def test_freeform_parse_lineno():
 
     for test in doctests:
         test._parse()
+        assert test._parts is not None
         assert test._parts[0].line_offset == 0
         offset = 0
         for p in test._parts:
@@ -218,7 +226,7 @@ def test_freeform_parse_lineno():
             offset += p.n_lines
 
 
-def test_collect_module_level():
+def test_collect_module_level() -> None:
     """
     pytest tests/test_core.py::test_collect_module_level -s -vv
 
@@ -256,7 +264,7 @@ def test_collect_module_level():
     temp.cleanup()
 
 
-def test_collect_module_level_singleline():
+def test_collect_module_level_singleline() -> None:
     """
     pytest tests/test_core.py::test_collect_module_level
 
@@ -285,13 +293,14 @@ def test_collect_module_level_singleline():
     temp.cleanup()
 
 
-def test_no_docstr():
+def test_no_docstr() -> None:
     """
     CommandLine:
         python -m test_core test_no_docstr
     """
     with utils.TempDir() as temp:
         dpath = temp.dpath
+        assert dpath is not None
         modpath = join(dpath, 'test_no_docstr.py')
         source = utils.codeblock(
             '''
@@ -309,12 +318,13 @@ def test_no_docstr():
         assert len(doctests) == 0
 
 
-def test_oneliner():
+def test_oneliner() -> None:
     """
     python ~/code/xdoctest/tests/test_core.py test_oneliner
     """
     with utils.TempDir() as temp:
         dpath = temp.dpath
+        assert dpath is not None
         modpath = join(dpath, 'test_oneliner.py')
         source = utils.codeblock(
             '''
@@ -335,7 +345,7 @@ def test_oneliner():
             doctests[0].run()
 
 
-def test_delayed_want_pass_cases():
+def test_delayed_want_pass_cases() -> None:
     """
     The delayed want algorithm allows a want statement to match trailing
     unmatched stdout if it fails to directly match the most recent stdout.
@@ -382,7 +392,7 @@ def test_delayed_want_pass_cases():
     assert status['passed']
 
 
-def test_delayed_want_fail_cases():
+def test_delayed_want_fail_cases() -> None:
     """
     CommandLine:
         xdoctest -m ~/code/xdoctest/tests/test_core.py test_delayed_want_fail_cases
@@ -439,7 +449,7 @@ def test_delayed_want_fail_cases():
     assert not status['passed']
 
 
-def test_indented_grouping():
+def test_indented_grouping() -> None:
     """
     Initial changes in 0.10.0 broke parsing of some ubelt tests, check to
     ensure using `...` in indented blocks is ok (as long as there is no want
@@ -475,7 +485,7 @@ def test_indented_grouping():
     assert status['passed']
 
 
-def test_backwards_compat_eval_in_loop():
+def test_backwards_compat_eval_in_loop() -> None:
     """
     Test that changes in 0.10.0 fix backwards compatibility issue.
 
@@ -509,7 +519,7 @@ def test_backwards_compat_eval_in_loop():
     assert status['passed']
 
 
-def test_backwards_compat_indent_value():
+def test_backwards_compat_indent_value() -> None:
     """
     CommandLine:
         xdoctest -m ~/code/xdoctest/tests/test_core.py test_backwards_compat_indent_value
@@ -529,7 +539,7 @@ def test_backwards_compat_indent_value():
     assert status['passed']
 
 
-def test_concise_try_except():
+def test_concise_try_except() -> None:
     """
     CommandLine:
         xdoctest -m ~/code/xdoctest/tests/test_core.py test_concise_try_except
@@ -563,7 +573,7 @@ def test_concise_try_except():
     assert status['passed']
 
 
-def test_semicolon_line():
+def test_semicolon_line() -> None:
     r"""
     Test for https://github.com/Erotemic/xdoctest/issues/108
 
@@ -639,9 +649,10 @@ def test_semicolon_line():
     assert status['passed']
 
 
-def test_collect_async_function_doctest():
+def test_collect_async_function_doctest() -> None:
     with utils.TempDir() as temp:
         dpath = temp.dpath
+        assert dpath is not None
         modpath = join(dpath, 'test_collect_async_function_doctest.py')
         source = utils.codeblock(
             '''

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -1,7 +1,7 @@
 from xdoctest import doctest_example, utils
 
 
-def test_inline_skip_directive():
+def test_inline_skip_directive() -> None:
     """
     pytest tests/test_directive.py::test_inline_skip_directive
     """
@@ -18,7 +18,7 @@ def test_inline_skip_directive():
     assert result['passed']
 
 
-def test_block_skip_directive():
+def test_block_skip_directive() -> None:
     """
     pytest tests/test_directive.py::test_block_skip_directive
     """
@@ -34,7 +34,7 @@ def test_block_skip_directive():
     assert result['passed']
 
 
-def test_multi_requires_directive():
+def test_multi_requires_directive() -> None:
     """
     Test semi-complex case with multiple requirements in a single line
 
@@ -66,13 +66,14 @@ def test_multi_requires_directive():
     )
     self = doctest_example.DocTest(docsrc=string)
     result = self.run(on_error='raise')
-    stdout = ''.join(list(self.logged_stdout.values()))
+    assert self.logged_stdout is not None
+    stdout = ''.join(str(v) for v in self.logged_stdout.values())
     assert result['passed']
     assert stdout.count('not-skipped') == 3
     assert stdout.count('is-skipped') == 0
 
 
-def test_directive_syntax_error():
+def test_directive_syntax_error() -> None:
     string = utils.codeblock(
         """
         >>> x = 0
@@ -87,7 +88,8 @@ def test_directive_syntax_error():
     assert not result['passed']
     assert 'Failed to parse' in result['exc_info'][1].args[0]
     assert 'line 4' in result['exc_info'][1].args[0]
-    stdout = ''.join(list(self.logged_stdout.values()))
+    assert self.logged_stdout is not None
+    stdout = ''.join(str(v) for v in self.logged_stdout.values())
     assert stdout.count('not-skipped') == 1
 
 

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -142,7 +142,9 @@ def test_format_src() -> None:
         utils.strip_ansi(self.format_src(colored=True, linenos=True))
         == string_with_lineno
     )
-    assert utils.strip_ansi(self.format_src(colored=True, linenos=False)) == string
+    assert (
+        utils.strip_ansi(self.format_src(colored=True, linenos=False)) == string
+    )
 
 
 def test_eval_expr_capture() -> None:

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from xdoctest import checker, constants, doctest_example, exceptions, utils
 import typing
 

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -1,7 +1,7 @@
 from xdoctest import checker, constants, doctest_example, exceptions, utils
 
 
-def test_exit_test_exception():
+def test_exit_test_exception() -> None:
     """
     pytest tests/test_doctest_example.py::test_exit_test_exception
     """
@@ -18,7 +18,7 @@ def test_exit_test_exception():
     assert result['passed']
 
 
-def test_failed_assign_want():
+def test_failed_assign_want() -> None:
     """
     pytest tests/test_doctest_example.py::test_exit_test_exception
     """
@@ -35,7 +35,7 @@ def test_failed_assign_want():
     assert 'Got nothing' in fail_text
 
 
-def test_continue_ambiguity():
+def test_continue_ambiguity() -> None:
     """
     pytest tests/test_doctest_example.py::test_exit_test_exception
     """
@@ -55,7 +55,7 @@ def test_continue_ambiguity():
     assert result['passed']
 
 
-def test_contination_want_ambiguity():
+def test_contination_want_ambiguity() -> None:
     """
     xdoctest ~/code/xdoctest/tests/test_doctest_example.py test_contination_want_ambiguity
     """
@@ -75,7 +75,7 @@ def test_contination_want_ambiguity():
     assert result['passed']
 
 
-def test_multiline_list():
+def test_multiline_list() -> None:
     """
     pytest tests/test_doctest_example.py::test_multiline_list
     """
@@ -92,7 +92,7 @@ def test_multiline_list():
     assert result['passed']
 
 
-def test_failure():
+def test_failure() -> None:
     string = utils.codeblock(
         """
         >>> i = 0
@@ -113,7 +113,7 @@ def test_failure():
     assert not result['passed']
 
 
-def test_format_src():
+def test_format_src() -> None:
     """
     python tests/test_doctest_example.py test_format_src
 
@@ -136,16 +136,16 @@ def test_format_src():
     self = doctest_example.DocTest(docsrc=string)
     self._parse()
 
-    assert self.format_src(colored=0, linenos=1) == string_with_lineno
-    assert self.format_src(colored=0, linenos=0) == string
+    assert self.format_src(colored=False, linenos=True) == string_with_lineno
+    assert self.format_src(colored=False, linenos=False) == string
     assert (
-        utils.strip_ansi(self.format_src(colored=1, linenos=1))
+        utils.strip_ansi(self.format_src(colored=True, linenos=True))
         == string_with_lineno
     )
-    assert utils.strip_ansi(self.format_src(colored=1, linenos=0)) == string
+    assert utils.strip_ansi(self.format_src(colored=True, linenos=False)) == string
 
 
-def test_eval_expr_capture():
+def test_eval_expr_capture() -> None:
     """
     pytest tests/test_doctest_example.py::test_eval_expr_capture -s
     """
@@ -159,6 +159,7 @@ def test_eval_expr_capture():
     )
     self = doctest_example.DocTest(docsrc=docsrc)
     self._parse()
+    assert self._parts is not None
     p1, p2 = self._parts
 
     # test_globals = {}
@@ -170,7 +171,19 @@ def test_eval_expr_capture():
         self.run()
     except Exception as ex:
         assert hasattr(ex, 'output_difference')
-        msg = ex.output_difference(colored=False)
+        assert callable(ex.output_difference)
+        # Narrow type for type checker
+        assert isinstance(ex, checker.GotWantException)
+        output_diff = ex.output_difference  # type: ignore[call-overload, misc]
+        msg = output_diff(colored=False)  # type: ignore[call-top-callable, unknown-argument, missing-argument]
+        assert msg == utils.codeblock(
+            """
+            Expected:
+                2
+            Got:
+                7
+            """
+        )
         assert msg == utils.codeblock(
             """
             Expected:
@@ -181,7 +194,7 @@ def test_eval_expr_capture():
         )
 
 
-def test_run_multi_want():
+def test_run_multi_want() -> None:
     docsrc = utils.codeblock(
         """
         >>> x = 2
@@ -199,7 +212,9 @@ def test_run_multi_want():
     result = self.run()
 
     assert result['passed']
+    assert self.logged_stdout is not None
     assert list(self.logged_stdout.values()) == ['', '', '', 'string\n']
+    assert self.logged_evals is not None
     assert list(self.logged_evals.values()) == [
         constants.NOT_EVALED,
         2,
@@ -208,7 +223,7 @@ def test_run_multi_want():
     ]
 
 
-def test_comment():
+def test_comment() -> None:
     docsrc = utils.codeblock(
         """
         >>> # foobar
@@ -216,6 +231,7 @@ def test_comment():
     )
     self = doctest_example.DocTest(docsrc=docsrc)
     self._parse()
+    assert self._parts is not None
     assert len(self._parts) == 1
     self.run(verbose=0)
 
@@ -227,6 +243,7 @@ def test_comment():
     )
     self = doctest_example.DocTest(docsrc=docsrc)
     self._parse()
+    assert self._parts is not None
     assert len(self._parts) == 1
     self.run(verbose=0)
 
@@ -240,6 +257,7 @@ def test_comment():
     )
     self = doctest_example.DocTest(docsrc=docsrc, lineno=1)
     self._parse()
+    assert self._parts is not None
     assert len(self._parts) == 1
     result = self.run(on_error='return', verbose=0)
     assert not result['passed']
@@ -247,7 +265,7 @@ def test_comment():
     assert self.failed_lineno() == 3
 
 
-def test_want_error_msg():
+def test_want_error_msg() -> None:
     """
     python tests/test_doctest_example.py test_want_error_msg
     pytest tests/test_doctest_example.py::test_want_error_msg
@@ -264,7 +282,7 @@ def test_want_error_msg():
     assert result['passed']
 
 
-def test_want_error_msg_failure():
+def test_want_error_msg_failure() -> None:
     """
     python tests/test_doctest_example.py test_want_error_msg_failure
     pytest tests/test_doctest_example.py::test_want_error_msg_failure
@@ -284,7 +302,7 @@ def test_want_error_msg_failure():
         self.run(on_error='raise')
 
 
-def test_await():
+def test_await() -> None:
     """
     python tests/test_doctest_example.py test_await
     pytest tests/test_doctest_example.py::test_await
@@ -302,7 +320,7 @@ def test_await():
     assert result['passed']
 
 
-def test_async_for():
+def test_async_for() -> None:
     """
     python tests/test_doctest_example.py test_async_for
     pytest tests/test_doctest_example.py::test_async_for
@@ -323,7 +341,7 @@ def test_async_for():
     assert result['passed']
 
 
-def test_async_with():
+def test_async_with() -> None:
     """
     python tests/test_doctest_example.py test_async_with
     pytest tests/test_doctest_example.py::test_async_with
@@ -348,7 +366,7 @@ def test_async_with():
     assert result['passed']
 
 
-def test_async_future_without_directive():
+def test_async_future_without_directive() -> None:
     """
     python tests/test_doctest_example.py test_async_future_without_directive
     pytest tests/test_doctest_example.py::test_async_future_without_directive
@@ -367,7 +385,7 @@ def test_async_future_without_directive():
     assert result['failed']
 
 
-def test_async_future_with_directive():
+def test_async_future_with_directive() -> None:
     """
     python tests/test_doctest_example.py test_async_future_with_directive
     pytest tests/test_doctest_example.py::test_async_future_with_directive
@@ -387,7 +405,7 @@ def test_async_future_with_directive():
     assert result['passed']
 
 
-def test_await_in_running_loop():
+def test_await_in_running_loop() -> None:
     """
     python tests/test_doctest_example.py test_await_in_running_loop
     pytest tests/test_doctest_example.py::test_await_in_running_loop
@@ -419,7 +437,7 @@ def test_await_in_running_loop():
     assert self.repr_failure()
 
 
-def test_async_def():
+def test_async_def() -> None:
     """
     python tests/test_doctest_example.py test_async_def
     pytest tests/test_doctest_example.py::test_async_def
@@ -439,7 +457,7 @@ def test_async_def():
     assert result['passed']
 
 
-def test_tabs_in_doctest():
+def test_tabs_in_doctest() -> None:
     """
     pytest tests/test_doctest_example.py::test_tabs_in_doctest
     """
@@ -458,6 +476,7 @@ def test_tabs_in_doctest():
     self = doctest_example.DocTest(docsrc=string)
 
     # This was ok in version 1.2.0
+    assert self.docsrc is not None
     assert tab in self.docsrc
 
     # Failed in 1.2.0

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
-from xdoctest import checker, constants, doctest_example, exceptions, utils
+
 import typing
+
+from xdoctest import checker, constants, doctest_example, exceptions, utils
+
 
 def test_exit_test_exception() -> None:
     """
@@ -427,7 +430,11 @@ def test_await_in_running_loop() -> None:
 
     self = doctest_example.DocTest(docsrc=string)
 
-    async def run_in_loop(doctest: doctest_example.DocTest, on_error: str, verbose : int | None = None) -> dict[str, typing.Any]:
+    async def run_in_loop(
+        doctest: doctest_example.DocTest,
+        on_error: str,
+        verbose: int | None = None,
+    ) -> dict[str, typing.Any]:
         return doctest.run(on_error=on_error, verbose=verbose)
 
     with pytest.raises(exceptions.ExistingEventLoopError):

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -1,5 +1,5 @@
 from xdoctest import checker, constants, doctest_example, exceptions, utils
-
+import typing
 
 def test_exit_test_exception() -> None:
     """
@@ -426,7 +426,7 @@ def test_await_in_running_loop() -> None:
 
     self = doctest_example.DocTest(docsrc=string)
 
-    async def run_in_loop(doctest, on_error, verbose=None):
+    async def run_in_loop(doctest: doctest_example.DocTest, on_error: str, verbose : int | None = None) -> dict[str, typing.Any]:
         return doctest.run(on_error=on_error, verbose=verbose)
 
     with pytest.raises(exceptions.ExistingEventLoopError):

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -17,7 +17,7 @@ TopLevelVisitor = static.TopLevelVisitor
 
 class SimpleDescriptor:
     def __init__(self) -> None:
-        self.value = 0
+        self.value : float | int = 0
 
     def __get__(self, instance, owner):
         return self.value

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -19,10 +19,10 @@ class SimpleDescriptor:
     def __init__(self) -> None:
         self.value : float | int = 0
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner) -> float | int:
         return self.value
 
-    def __set__(self, instance, value) -> None:
+    def __set__(self, instance, value : float | int) -> None:
         self.value = float(value)
 
 

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -4,6 +4,7 @@ This mod has a docstring
 Example:
     >>> pass
 """
+
 from __future__ import annotations
 
 import sys
@@ -18,12 +19,12 @@ TopLevelVisitor = static.TopLevelVisitor
 
 class SimpleDescriptor:
     def __init__(self) -> None:
-        self.value : float | int = 0
+        self.value: float | int = 0
 
     def __get__(self, instance, owner) -> float | int:
         return self.value
 
-    def __set__(self, instance, value : float | int) -> None:
+    def __set__(self, instance, value: float | int) -> None:
         self.value = float(value)
 
 

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -16,13 +16,13 @@ TopLevelVisitor = static.TopLevelVisitor
 
 
 class SimpleDescriptor:
-    def __init__(self):
+    def __init__(self) -> None:
         self.value = 0
 
     def __get__(self, instance, owner):
         return self.value
 
-    def __set__(self, instance, value):
+    def __set__(self, instance, value) -> None:
         self.value = float(value)
 
 
@@ -37,10 +37,10 @@ class SimpleClass:
     # Injected funcs should not be part of the calldefs
     visit = TopLevelVisitor.visit
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.inst_attr = SimpleDescriptor()
 
-        def submethod1():
+        def submethod1() -> None:
             """
             Example:
                 >>> pass
@@ -48,7 +48,7 @@ class SimpleClass:
             pass
 
     @classmethod
-    def method1(cls):
+    def method1(cls) -> None:
         """
         Example:
             >>> pass
@@ -56,7 +56,7 @@ class SimpleClass:
         pass
 
     @staticmethod
-    def method2():
+    def method2() -> None:
         """
         Example:
             >>> pass
@@ -64,14 +64,14 @@ class SimpleClass:
         pass
 
     @property
-    def method3(self):
+    def method3(self) -> None:
         """
         Example:
             >>> pass
         """
         pass
 
-    def method4(self):
+    def method4(self) -> None:
         """
         Example:
             >>> pass
@@ -79,7 +79,7 @@ class SimpleClass:
         pass
 
 
-def simple_func1():
+def simple_func1() -> None:
     """
     Example:
         >>> pass
@@ -87,13 +87,13 @@ def simple_func1():
     pass
 
 
-def test_parse_dynamic_calldefs():
+def test_parse_dynamic_calldefs() -> None:
     """
     CommandLine:
         python tests/test_dynamic.py test_parse_dynamic_calldefs
     """
 
-    def subfunc():
+    def subfunc() -> None:
         """
         Example:
             >>> pass
@@ -102,6 +102,7 @@ def test_parse_dynamic_calldefs():
 
     module = sys.modules[test_parse_dynamic_calldefs.__module__]
     modpath = module.__file__
+    assert modpath is not None
     calldefs = dynamic.parse_dynamic_calldefs(modpath)
     keys = [
         '__doc__',
@@ -133,7 +134,7 @@ def test_parse_dynamic_calldefs():
     assert 'TopLevelVisitor' in dir(module)
 
 
-def test_defined_by_module():
+def test_defined_by_module() -> None:
     """
     CommandLine:
         python tests/test_dynamic.py test_defined_by_module
@@ -189,10 +190,11 @@ def test_defined_by_module():
 
     import inspect
 
+    # Use getattr to avoid unresolved-attribute errors for non-standard attributes
     items = [
-        inspect.re,
-        inspect.re.sub,
-        inspect.re.enum,
+        inspect,
+        getattr(inspect, 'sub', None),
+        getattr(inspect, 'enum', None),
     ]
     module = inspect
 
@@ -202,7 +204,7 @@ def test_defined_by_module():
         assert not flag, '{} should be not defined by {}'.format(item, module)
 
 
-def test_programatically_generated_docstrings():
+def test_programatically_generated_docstrings() -> None:
     """
     Test that the "dynamic" analysis mode works on dynamically generated
     docstrings.

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -4,6 +4,7 @@ This mod has a docstring
 Example:
     >>> pass
 """
+from __future__ import annotations
 
 import sys
 

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -5,9 +5,10 @@ import sys
 import pytest
 
 from xdoctest import utils
+from typing import cast
 
 
-def cmd(command):
+def cmd(command: str) -> dict[str, object]:
     # simplified version of ub.cmd no fancy tee behavior
     proc = subprocess.Popen(
         command,
@@ -81,7 +82,7 @@ def test_xdoc_console_script_exec() -> None:
     else:
         info = cmd('xdoctest')
     print('info = {!r}'.format(info))
-    assert 'usage' in info['err']
+    assert 'usage' in cast(str, info['err'])
 
 
 def test_xdoc_cli_version() -> None:
@@ -116,7 +117,7 @@ def test_xdoc_cli_version() -> None:
         info = ub.cmd(sys.executable + ' -m xdoctest --version')
     print('info = {!r}'.format(info))
     print('xdoctest.__version__ = {!r}'.format(xdoctest.__version__))
-    assert xdoctest.__version__ in info['out']
+    assert xdoctest.__version__ in cast(str, info['out'])
 
 
 if __name__ == '__main__':

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -27,14 +27,14 @@ def cmd(command):
     return info
 
 
-def skip_if_not_installed():
+def skip_if_not_installed() -> None:
     # If xdoctest is not installed via `pip install -e`
     # then skip these tests because the entry point wont exist
     if not utils.is_modname_importable('xdoctest'):
         pytest.skip('Can only test entry points if xdoctest is installed.')
 
 
-def test_xdoc_console_script_location():
+def test_xdoc_console_script_location() -> None:
     skip_if_not_installed()
 
     if sys.platform.startswith('freebsd'):
@@ -63,7 +63,7 @@ def test_xdoc_console_script_location():
         assert script_fname.startswith('xdoctest')
 
 
-def test_xdoc_console_script_exec():
+def test_xdoc_console_script_exec() -> None:
     skip_if_not_installed()
     if sys.platform.startswith('freebsd'):
         pytest.skip(
@@ -84,7 +84,7 @@ def test_xdoc_console_script_exec():
     assert 'usage' in info['err']
 
 
-def test_xdoc_cli_version():
+def test_xdoc_cli_version() -> None:
     """
     CommandLine:
         python -m xdoctest -m ~/code/xdoctest/tests/test_entry_point.py test_xdoc_cli_version

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 import os
 import subprocess
 import sys
+from typing import cast
 
 import pytest
 
 from xdoctest import utils
-from typing import cast
 
 
 def cmd(command: str) -> dict[str, 'subprocess.Popen[str] | str | int']:

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import subprocess
 import sys
@@ -8,7 +9,7 @@ from xdoctest import utils
 from typing import cast
 
 
-def cmd(command: str) -> dict[str, object]:
+def cmd(command: str) -> dict[str, 'subprocess.Popen[str] | str | int']:
     # simplified version of ub.cmd no fancy tee behavior
     proc = subprocess.Popen(
         command,
@@ -19,7 +20,7 @@ def cmd(command: str) -> dict[str, object]:
     )
     out, err = proc.communicate()
     ret = proc.wait()
-    info = {
+    info: dict[str, 'subprocess.Popen[str] | str | int'] = {
         'proc': proc,
         'out': out,
         'err': err,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,6 +3,7 @@ from os.path import join
 
 import pytest
 
+from typing import cast
 from xdoctest import core, exceptions, runner, utils
 from xdoctest.utils.util_misc import _run_case
 
@@ -20,7 +21,7 @@ def test_parse_syntax_error() -> None:
             """
     )
 
-    info = {
+    info : dict[str, str | int | None] = {
         'callname': 'test_synerr',
         'lineno': 42,
         'fpath': None,
@@ -33,8 +34,8 @@ def test_parse_syntax_error() -> None:
         f_doctests = list(
             core.parse_docstr_examples(
                 docstr,
-                callname=info['callname'],
-                lineno=info['lineno'],
+                callname=cast(str, info['callname']),
+                lineno=cast(int, info['lineno']),
                 style='freeform',
                 modpath=None,
                 fpath=None,
@@ -46,8 +47,8 @@ def test_parse_syntax_error() -> None:
         g_doctests = list(
             core.parse_docstr_examples(
                 docstr,
-                callname=info['callname'],
-                lineno=info['lineno'],
+                callname=cast(str, info['callname']),
+                lineno=cast(int, info['lineno']),
                 style='google',
                 modpath=None,
                 fpath=None,
@@ -71,8 +72,8 @@ def test_parse_syntax_error() -> None:
     g_doctests2 = list(
         core.parse_google_docstr_examples(
             docstr,
-            callname=info['callname'],
-            lineno=info['lineno'],
+            callname=cast(str, info['callname']),
+            lineno=cast(int, info['lineno']),
             eager_parse=False,
             modpath=None,
             fpath=None,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,9 +1,9 @@
 import warnings
 from os.path import join
+from typing import cast
 
 import pytest
 
-from typing import cast
 from xdoctest import core, exceptions, runner, utils
 from xdoctest.utils.util_misc import _run_case
 
@@ -21,7 +21,7 @@ def test_parse_syntax_error() -> None:
             """
     )
 
-    info : dict[str, str | int | None] = {
+    info: dict[str, str | int | None] = {
         'callname': 'test_synerr',
         'lineno': 42,
         'fpath': None,
@@ -227,13 +227,13 @@ def test_traceback_rewrite_handles_inner_frame_from_prior_part():
     from xdoctest import doctest_example, utils
 
     docsrc = utils.codeblock(
-        '''
+        """
         >>> def foo():
         >>>     raise ValueError('boom')
         >>> print('ready')
         ready
         >>> foo()
-        '''
+        """
     )
     self = doctest_example.DocTest(docsrc=docsrc, lineno=1)
     result = self.run(on_error='return', verbose=0)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,52 +6,8 @@ import pytest
 from xdoctest import core, exceptions, runner, utils
 from xdoctest.utils.util_misc import _run_case
 
-# def _check_syntaxerror_behavior():
-#     import ubelt as ub
-#     source_block = ub.codeblock(
-#         '''
-#         x = 3
-#         3 = 5
-#         ''')
-#     try:
-#         compile(source_block, filename='<string>', mode='exec')
-#     except SyntaxError as ex1:
-#         print('ex1.text = {!r}'.format(ex1.text))
-#         print('ex1.offset = {!r}'.format(ex1.offset))
-#         print('ex1.lineno = {!r}'.format(ex1.lineno))
 
-#     import ast
-#     try:
-#         pt = ast.parse(source_block)
-#     except SyntaxError as ex2:
-#         print('ex2.text = {!r}'.format(ex2.text))
-#         print('ex2.offset = {!r}'.format(ex2.offset))
-#         print('ex2.lineno = {!r}'.format(ex2.lineno))
-
-#     fpath = join(ub.ensure_app_cache_dir('xdoctest', 'test'), 'source.py')
-#     ub.writeto(fpath, source_block)
-#     try:
-#         compile(source_block, filename=fpath, mode='exec')
-#     except SyntaxError as ex2:
-#         print('ex2.text = {!r}'.format(ex2.text))
-#         print('ex2.offset = {!r}'.format(ex2.offset))
-#         print('ex2.lineno = {!r}'.format(ex2.lineno))
-
-#     import tempfile
-#     import ast
-#     temp = tempfile.NamedTemporaryFile()
-#     temp.file.write((source_block + '\n').encode('utf8'))
-#     temp.file.seek(0)
-#     try:
-#         ast.parse(source_block, temp.name)
-#     except SyntaxError as ex2:
-#         print('ex2.text = {!r}'.format(ex2.text))
-#         print('ex2.offset = {!r}'.format(ex2.offset))
-#         print('ex2.lineno = {!r}'.format(ex2.lineno))
-#         raise
-
-
-def test_parse_syntax_error():
+def test_parse_syntax_error() -> None:
     """
     CommandLine:
         python tests/test_errors.py test_parse_syntax_error
@@ -64,18 +20,24 @@ def test_parse_syntax_error():
             """
     )
 
-    info = {'callname': 'test_synerr', 'lineno': 42}
+    info = {'callname': 'test_synerr', 'lineno': 42, 'fpath': None, 'parser_kw': None}
 
     # Eager parsing should cause no doctests with errors to be found
     # and warnings should be raised
     with warnings.catch_warnings(record=True) as f_warnlist:
         f_doctests = list(
-            core.parse_docstr_examples(docstr, style='freeform', **info)
+            core.parse_docstr_examples(
+                docstr, callname=info['callname'], lineno=info['lineno'],
+                style='freeform', modpath=None, fpath=None, parser_kw=None
+            )
         )
 
     with warnings.catch_warnings(record=True) as g_warnlist:
         g_doctests = list(
-            core.parse_docstr_examples(docstr, style='google', **info)
+            core.parse_docstr_examples(
+                docstr, callname=info['callname'], lineno=info['lineno'],
+                style='google', modpath=None, fpath=None, parser_kw=None
+            )
         )
 
     for w in g_warnlist:
@@ -92,7 +54,10 @@ def test_parse_syntax_error():
     # Google style can find doctests with bad syntax, but parsing them
     # results in an error.
     g_doctests2 = list(
-        core.parse_google_docstr_examples(docstr, eager_parse=False, **info)
+        core.parse_google_docstr_examples(
+            docstr, callname=info['callname'], lineno=info['lineno'],
+            eager_parse=False, modpath=None, fpath=None
+        )
     )
     assert len(g_doctests2) == 1
     for example in g_doctests2:
@@ -100,7 +65,7 @@ def test_parse_syntax_error():
             example._parse()
 
 
-def test_runner_syntax_error():
+def test_runner_syntax_error() -> None:
     """
     python tests/test_errors.py test_runner_syntax_error
     pytest tests/test_errors.py -k test_runner_syntax_error
@@ -146,6 +111,7 @@ def test_runner_syntax_error():
     temp = utils.TempDir(persist=True)
     temp.ensure()
     dpath = temp.dpath
+    assert dpath is not None
     modpath = join(dpath, 'demo_runner_syntax_error.py')
     with open(modpath, 'w') as file:
         file.write(source)
@@ -156,6 +122,7 @@ def test_runner_syntax_error():
         )
 
     print('CAPTURED [[[[[[[[')
+    assert cap.text is not None
     print(utils.indent(cap.text))
     print(']]]]]]]] # CAPTURED')
 
@@ -170,7 +137,7 @@ def test_runner_syntax_error():
     assert '1 passed' in captext
 
 
-def test_parse_doctset_error():
+def test_parse_doctset_error() -> None:
     source = utils.codeblock(
         '''
         def func_with_an_unparsable_google_docstr(a):
@@ -194,7 +161,7 @@ def test_parse_doctset_error():
     del text
 
 
-def test_extract_got_exception():
+def test_extract_got_exception() -> None:
     """
     Make a repr that fails
 
@@ -216,6 +183,7 @@ def test_extract_got_exception():
           '''
     )
     text = _run_case(source, style='google')
+    assert text is not None
     assert 'ExtractGotReprException' in text
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -207,6 +207,47 @@ def test_extract_got_exception() -> None:
     assert 'ExtractGotReprException' in text
 
 
+def test_traceback_rewrite_handles_inner_frame_from_prior_part():
+    """
+    Regression test for a traceback-formatting bug when a later doctest part
+    called a function defined in an earlier part.
+
+    Before the fix, `repr_failure()` assumed traceback lines always belonged to
+    `self.failed_part`. In this case that was wrong: the call site was in the
+    later part, but the actual exception came from the earlier part that
+    defined `foo`. As a result, traceback rewriting could index into the wrong
+    part's `orig_lines` and crash with `IndexError`.
+
+    The fix was to give each doctest part its own synthetic filename and map
+    traceback frames back to the part that actually owns them.
+
+    This test verifies that `repr_failure()` no longer crashes and that the
+    reported failure still points to the real exception.
+    """
+    from xdoctest import doctest_example, utils
+
+    docsrc = utils.codeblock(
+        '''
+        >>> def foo():
+        >>>     raise ValueError('boom')
+        >>> print('ready')
+        ready
+        >>> foo()
+        '''
+    )
+    self = doctest_example.DocTest(docsrc=docsrc, lineno=1)
+    result = self.run(on_error='return', verbose=0)
+    assert result['failed']
+
+    text = '\n'.join(self.repr_failure())
+    assert 'ValueError' in text
+    assert 'boom' in text
+
+    # This is the more important semantic check.
+    # The actual failing line is the raise inside foo(), not the foo() call.
+    assert self.failed_lineno() == 2
+
+
 if __name__ == '__main__':
     """
     CommandLine:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -20,23 +20,38 @@ def test_parse_syntax_error() -> None:
             """
     )
 
-    info = {'callname': 'test_synerr', 'lineno': 42, 'fpath': None, 'parser_kw': None}
+    info = {
+        'callname': 'test_synerr',
+        'lineno': 42,
+        'fpath': None,
+        'parser_kw': None,
+    }
 
     # Eager parsing should cause no doctests with errors to be found
     # and warnings should be raised
     with warnings.catch_warnings(record=True) as f_warnlist:
         f_doctests = list(
             core.parse_docstr_examples(
-                docstr, callname=info['callname'], lineno=info['lineno'],
-                style='freeform', modpath=None, fpath=None, parser_kw=None
+                docstr,
+                callname=info['callname'],
+                lineno=info['lineno'],
+                style='freeform',
+                modpath=None,
+                fpath=None,
+                parser_kw=None,
             )
         )
 
     with warnings.catch_warnings(record=True) as g_warnlist:
         g_doctests = list(
             core.parse_docstr_examples(
-                docstr, callname=info['callname'], lineno=info['lineno'],
-                style='google', modpath=None, fpath=None, parser_kw=None
+                docstr,
+                callname=info['callname'],
+                lineno=info['lineno'],
+                style='google',
+                modpath=None,
+                fpath=None,
+                parser_kw=None,
             )
         )
 
@@ -55,8 +70,12 @@ def test_parse_syntax_error() -> None:
     # results in an error.
     g_doctests2 = list(
         core.parse_google_docstr_examples(
-            docstr, callname=info['callname'], lineno=info['lineno'],
-            eager_parse=False, modpath=None, fpath=None
+            docstr,
+            callname=info['callname'],
+            lineno=info['lineno'],
+            eager_parse=False,
+            modpath=None,
+            fpath=None,
         )
     )
     assert len(g_doctests2) == 1

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,2 +1,2 @@
-def test_import():
+def test_import() -> None:
     pass

--- a/tests/test_limitations.py
+++ b/tests/test_limitations.py
@@ -7,7 +7,7 @@ from xdoctest import utils
 from xdoctest.utils.util_misc import _run_case
 
 
-def test_pathological_property_case():
+def test_pathological_property_case() -> None:
     """
     This case actually wont error, but it displays a limitation of static
     analysis. We trick the doctest node parser into thinking there is a setter
@@ -41,6 +41,7 @@ def test_pathological_property_case():
         '''
         )
     )
+    assert text is not None
     # If there was a way to make this case fail, that would be ok
     assert 'Test.test:0' in text
     # assert 'Test.test.fset:0' in text

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -34,7 +34,7 @@ def skip_notebook_tests_if_unsupported() -> None:
         pytest.skip('Missing jupyter')
 
 
-def cmd(command):
+def cmd(command: str) -> dict[str, object]:
     # simplified version of ub.cmd no fancy tee behavior
     import subprocess
 
@@ -56,7 +56,7 @@ def cmd(command):
     return info
 
 
-def demodata_notebook_fpath():
+def demodata_notebook_fpath() -> str:
     try:
         testdir = dirname(__file__)
     except NameError:
@@ -105,4 +105,5 @@ def test_xdoctest_outside_notebook() -> None:
     notebook_fpath = demodata_notebook_fpath()
     info = cmd(sys.executable + ' -m xdoctest ' + notebook_fpath)
     text = info['out']
+    assert isinstance(text, str)
     assert '3 / 3 passed' in text

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from os.path import dirname, exists, join
 from typing import Any

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -6,7 +6,7 @@ import pytest
 try:
     from packaging.version import parse as LooseVersion
 except ImportError:
-    from distutils.version import LooseVersion
+    from distutils.version import LooseVersion  # type: ignore
 
 PY_VERSION = LooseVersion('{}.{}'.format(*sys.version_info[0:2]))
 IS_MODERN_PYTHON = PY_VERSION > LooseVersion('3.4')

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 import sys
 from os.path import dirname, exists, join
+from typing import Any
 
 import pytest
 
@@ -34,7 +36,7 @@ def skip_notebook_tests_if_unsupported() -> None:
         pytest.skip('Missing jupyter')
 
 
-def cmd(command: str) -> dict[str, object]:
+def cmd(command: str) -> dict[str, 'Any']:
     # simplified version of ub.cmd no fancy tee behavior
     import subprocess
 
@@ -47,7 +49,7 @@ def cmd(command: str) -> dict[str, object]:
     )
     out, err = proc.communicate()
     ret = proc.wait()
-    info = {
+    info: dict[str, 'Any'] = {
         'proc': proc,
         'out': out,
         'test_doctest_in_notebook.ipynberr': err,

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -12,7 +12,7 @@ PY_VERSION = LooseVersion('{}.{}'.format(*sys.version_info[0:2]))
 IS_MODERN_PYTHON = PY_VERSION > LooseVersion('3.4')
 
 
-def skip_notebook_tests_if_unsupported():
+def skip_notebook_tests_if_unsupported() -> None:
     if not IS_MODERN_PYTHON:
         pytest.skip('jupyter support is only for modern python versions')
 
@@ -69,7 +69,7 @@ def demodata_notebook_fpath():
     return notebook_fpath
 
 
-def test_xdoctest_inside_notebook():
+def test_xdoctest_inside_notebook() -> None:
     """
     xdoctest ~/code/xdoctest/tests/test_notebook.py test_xdoctest_inside_notebook
     xdoctest tests/test_notebook.py test_xdoctest_inside_notebook
@@ -96,7 +96,7 @@ def test_xdoctest_inside_notebook():
         )
 
 
-def test_xdoctest_outside_notebook():
+def test_xdoctest_outside_notebook() -> None:
     skip_notebook_tests_if_unsupported()
 
     if sys.platform.startswith('win32'):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,7 @@ from xdoctest.doctest_part import DoctestPart
 from xdoctest import exceptions, parser, utils
 
 
-def test_final_eval_exec():
+def test_final_eval_exec() -> None:
     """
     Ensure that if the line before a want is able to be evaled, it is so we can
     compare its value to the want value.
@@ -24,8 +24,8 @@ def test_final_eval_exec():
     DEBUG = 0
     if DEBUG:
         print(string)
-        print([p.compile_mode for p in parts])
-    assert [p.compile_mode for p in parts] == ['exec', 'eval']
+        print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
 
     string = utils.codeblock(
         """
@@ -37,8 +37,8 @@ def test_final_eval_exec():
     parts = self.parse(string)
     if DEBUG:
         print(string)
-        print([p.compile_mode for p in parts])
-    assert [p.compile_mode for p in parts] == ['exec']
+        print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec']
 
     string = utils.codeblock(
         r'''
@@ -54,8 +54,8 @@ def test_final_eval_exec():
     parts = self.parse(string)
     if DEBUG:
         print(string)
-        print([p.compile_mode for p in parts])
-    assert [p.compile_mode for p in parts] == ['exec', 'single']
+        print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'single']
 
     string = utils.codeblock(
         r"""
@@ -68,8 +68,8 @@ def test_final_eval_exec():
     parts = self.parse(string)
     if DEBUG:
         print(string)
-        print([p.compile_mode for p in parts])
-    assert [p.compile_mode for p in parts] == ['exec', 'eval']
+        print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
 
     string = utils.codeblock(
         r"""
@@ -82,11 +82,11 @@ def test_final_eval_exec():
     parts = self.parse(string)
     if DEBUG:
         print(string)
-        print([p.compile_mode for p in parts])
-    assert [p.compile_mode for p in parts] == ['single']
+        print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['single']
 
 
-def test_compile_mode_print():
+def test_compile_mode_print() -> None:
     string = utils.codeblock(
         r"""
         >>> x = 2
@@ -97,10 +97,10 @@ def test_compile_mode_print():
     )
     self = parser.DoctestParser()
     parts = self.parse(string)
-    assert [p.compile_mode for p in parts] == ['exec', 'eval']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
 
 
-def test_label_lines():
+def test_label_lines() -> None:
     string = utils.codeblock(
         r"""
         >>> i = 0
@@ -117,7 +117,7 @@ def test_label_lines():
     ]
 
 
-def test_label_indented_lines():
+def test_label_indented_lines() -> None:
     string = '''
             text
             >>> dsrc1()
@@ -185,7 +185,7 @@ def test_label_indented_lines():
     assert labeled == expected
 
 
-def test_ps1_linenos_1():
+def test_ps1_linenos_1() -> None:
     """
     Test we can find the line numbers for every "evaluatable" statement
     """
@@ -202,7 +202,7 @@ def test_ps1_linenos_1():
     assert linenos == [0, 1]
 
 
-def test_ps1_linenos_2():
+def test_ps1_linenos_2() -> None:
     source_lines = utils.codeblock(
         '''
         >>> x = """
@@ -218,7 +218,7 @@ def test_ps1_linenos_2():
     assert linenos == [0, 3]
 
 
-def test_ps1_linenos_3():
+def test_ps1_linenos_3() -> None:
     source_lines = utils.codeblock(
         '''
         >>> x = """
@@ -234,7 +234,7 @@ def test_ps1_linenos_3():
     assert linenos == [0, 3]
 
 
-def test_ps1_linenos_4():
+def test_ps1_linenos_4() -> None:
     source_lines = utils.codeblock(
         '''
         >>> x = """
@@ -267,7 +267,7 @@ def test_ps1_linenos_4():
     assert linenos == [0, 3, 5, 9, 13, 16, 17, 20]
 
 
-def test_retain_source():
+def test_retain_source() -> None:
     """ """
     source = utils.codeblock(
         """
@@ -282,11 +282,13 @@ def test_retain_source():
     assert mode_hint == 'eval'
     assert linenos == [0, 1]
     p1, p2 = self.parse(source)
+    assert isinstance(p1, DoctestPart)
+    assert isinstance(p2, DoctestPart)
     assert p1.source == 'x = 2'
     assert p2.source == 'print("foo")'
 
 
-def test_package_string_tup():
+def test_package_string_tup() -> None:
     """
     pytest tests/test_parser.py::test_package_string_tup
     """
@@ -297,9 +299,9 @@ def test_package_string_tup():
     assert len(parts) == 1, 'should only want one string'
 
 
-def test_simulate_repl():
+def test_simulate_repl() -> None:
     """
-    pytest tests/test_parser.py::test_package_string_tup
+    pytest tests/test_parser.py::test_simulate_repl
     """
     string = utils.codeblock(
         """
@@ -315,7 +317,7 @@ def test_simulate_repl():
     assert len(self.parse(string)) == 3
 
 
-def test_parse_multi_want():
+def test_parse_multi_want() -> None:
     string = utils.codeblock(
         """
         >>> x = 2
@@ -331,11 +333,12 @@ def test_parse_multi_want():
     parts = self.parse(string)
 
     self._label_docsrc_lines(string)
+    assert isinstance(parts[2], DoctestPart)
     assert parts[2].source == "'string'"
     assert len(parts) == 4
 
 
-def test_parse_eval_nowant():
+def test_parse_eval_nowant() -> None:
     string = utils.codeblock(
         """
         >>> a = 1
@@ -352,7 +355,7 @@ def test_parse_eval_nowant():
     assert len(parts) == 1
 
 
-def test_parse_eval_single_want():
+def test_parse_eval_single_want() -> None:
     string = utils.codeblock(
         """
         >>> a = 1
@@ -370,7 +373,7 @@ def test_parse_eval_single_want():
     assert len(parts) == 2
 
 
-def test_parse_comment():
+def test_parse_comment() -> None:
     string = utils.codeblock(
         """
         >>> # nothing
@@ -382,6 +385,7 @@ def test_parse_comment():
     source_lines = string.split('\n')[:]
     linenos, mode_hint = self._locate_ps1_linenos(source_lines)
     parts = self.parse(string)
+    assert isinstance(parts[0], DoctestPart)
     assert parts[0].source.strip().startswith('#')
 
 
@@ -479,7 +483,7 @@ def test_parse_comment_with_mixed_indentation_levels() -> None:
         assert text in combined
 
 
-def test_text_after_want():
+def test_text_after_want() -> None:
     string = utils.codeblock("""
         Example:
             >>> dsrc()
@@ -497,7 +501,7 @@ def test_text_after_want():
     assert labeled == expected
 
 
-def test_want_ellipse_with_space():
+def test_want_ellipse_with_space() -> None:
     string = utils.codeblock("""
         Example:
             >>> dsrc()
@@ -517,7 +521,7 @@ def test_want_ellipse_with_space():
     assert labeled == expected
 
 
-def test_syntax_error():
+def test_syntax_error() -> None:
     string = utils.codeblock("""
         Example:
             >>> 03 = dsrc()
@@ -527,7 +531,7 @@ def test_syntax_error():
         self.parse(string)
 
 
-def test_nonbalanced_statement():
+def test_nonbalanced_statement() -> None:
     """
     xdoctest ~/code/xdoctest/tests/test_parser.py test_nonbalanced_statement
 
@@ -545,11 +549,14 @@ def test_nonbalanced_statement():
     self = parser.DoctestParser()
     with pytest.raises(exceptions.DoctestParseError) as exc_info:
         self.parse(string)
-    msg = exc_info.value.orig_ex.msg.lower()
+    ex : exceptions.DoctestParseError = exc_info.value
+    orig_ex = ex.orig_ex
+    assert isinstance(orig_ex, exceptions.IncompleteParseError)
+    msg = orig_ex.msg.lower()
     assert msg.startswith('ill-formed doctest'.lower())
 
 
-def test_bad_indent():
+def test_bad_indent() -> None:
     """
     CommandLine:
         python tests/test_parser.py test_bad_indent
@@ -565,18 +572,21 @@ def test_bad_indent():
     self = parser.DoctestParser()
     with pytest.raises(exceptions.DoctestParseError) as exc_info:
         self.parse(string)
-    msg = exc_info.value.orig_ex.msg.lower()
+    ex : exceptions.DoctestParseError = exc_info.value
+    orig_ex = ex.orig_ex
+    assert isinstance(orig_ex, SyntaxError), repr(type(orig_ex))
+    msg = orig_ex.msg.lower()
     assert msg.startswith('Bad indentation in doctest'.lower())
 
 
-def test_part_nice_no_lineoff():
+def test_part_nice_no_lineoff() -> None:
     from xdoctest import doctest_part
 
-    self = doctest_part.DoctestPart([], [], None)
-    assert str(self) == '<DoctestPart(src="", want=None)>'
+    self = doctest_part.DoctestPart([], [], 0)
+    assert str(self) == '<DoctestPart(ln 0, src="", want=None)>'
 
 
-def test_repl_oneline():
+def test_repl_oneline() -> None:
     string = utils.codeblock(
         """
         >>> x = 1
@@ -584,10 +594,10 @@ def test_repl_oneline():
     )
     self = parser.DoctestParser(simulate_repl=True)
     parts = self.parse(string)
-    assert [p.source for p in parts] == ['x = 1']
+    assert [p.source for p in parts if isinstance(p, DoctestPart)] == ['x = 1']
 
 
-def test_repl_twoline():
+def test_repl_twoline() -> None:
     string = utils.codeblock(
         """
         >>> x = 1
@@ -596,10 +606,10 @@ def test_repl_twoline():
     )
     self = parser.DoctestParser(simulate_repl=True)
     parts = self.parse(string)
-    assert [p.source for p in parts] == ['x = 1', 'x = 2']
+    assert [p.source for p in parts if isinstance(p, DoctestPart)] == ['x = 1', 'x = 2']
 
 
-def test_repl_comment_in_string():
+def test_repl_comment_in_string() -> None:
     source_lines = ['>>> x = """', '    # comment in a string', '    """']
     self = parser.DoctestParser()
     assert self._locate_ps1_linenos(source_lines) == ([0], 'exec')
@@ -616,7 +626,7 @@ def test_repl_comment_in_string():
     assert self._locate_ps1_linenos(source_lines) == ([0, 3], 'exec')
 
 
-def test_inline_directive():
+def test_inline_directive() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_inline_directive
     """
@@ -653,9 +663,10 @@ def test_inline_directive():
     parts = self.parse(string)
     # assert len(parts) ==
     for part in parts:
-        print('----')
-        print(part.source)
-        print('----')
+        if isinstance(part, DoctestPart):
+            print('----')
+            print(part.source)
+            print('----')
     try:
         print(parts)
     except ImportError:
@@ -663,7 +674,7 @@ def test_inline_directive():
     # TODO: finish me
 
 
-def test_block_directive_nowant1():
+def test_block_directive_nowant1() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_nowant1
     """
@@ -679,7 +690,8 @@ def test_block_directive_nowant1():
     parts = self.parse(string)
     print('----')
     for part in parts:
-        print(part.source)
+        if isinstance(part, DoctestPart):
+            print(part.source)
         print('----')
     try:
         print(parts)
@@ -688,7 +700,7 @@ def test_block_directive_nowant1():
     assert len(parts) == 1
 
 
-def test_block_directive_nowant2():
+def test_block_directive_nowant2() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_nowant
     """
@@ -709,7 +721,7 @@ def test_block_directive_nowant2():
     assert len(parts) == 2
 
 
-def test_block_directive_want1_assign():
+def test_block_directive_want1_assign() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_want1
     """
@@ -725,7 +737,8 @@ def test_block_directive_want1_assign():
     parts = self.parse(string)
     print('----')
     for part in parts:
-        print(part.source)
+        if isinstance(part, DoctestPart):
+            print(part.source)
         print('----')
     try:
         print(parts)
@@ -734,7 +747,7 @@ def test_block_directive_want1_assign():
     assert len(parts) == 1
 
 
-def test_block_directive_want1_eval():
+def test_block_directive_want1_eval() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_want1
     """
@@ -751,7 +764,7 @@ def test_block_directive_want1_eval():
     assert len(parts) == 2
 
 
-def test_block_directive_want2_assign():
+def test_block_directive_want2_assign() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_want2
     """
@@ -769,7 +782,7 @@ def test_block_directive_want2_assign():
     assert len(parts) == 2
 
 
-def test_block_directive_want2_eval():
+def test_block_directive_want2_eval() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_want2_eval
     """
@@ -786,7 +799,8 @@ def test_block_directive_want2_eval():
     parts = self.parse(string)
     print('----')
     for part in parts:
-        print(part.source)
+        if isinstance(part, DoctestPart):
+            print(part.source)
         print('----')
     try:
         print(parts)
@@ -795,7 +809,7 @@ def test_block_directive_want2_eval():
     assert len(parts) == 3
 
 
-def test_block_directive_want2_eval2():
+def test_block_directive_want2_eval2() -> None:
     """
     python ~/code/xdoctest/tests/test_parser.py test_block_directive_want2_eval
     """
@@ -819,7 +833,7 @@ def test_block_directive_want2_eval2():
     assert len(parts) == 4
 
 
-def test_gh_issue_25_parsing_failure():
+def test_gh_issue_25_parsing_failure() -> None:
     string = utils.codeblock(
         """
         >>> _, o = 0, 1
@@ -845,7 +859,7 @@ def test_gh_issue_25_parsing_failure():
     assert len(parts) == 1
 
 
-def test_parser_with_type_annot():
+def test_parser_with_type_annot() -> None:
     string = utils.codeblock(
         """
         >>> def foo(x: str) -> None:
@@ -860,7 +874,7 @@ def test_parser_with_type_annot():
     assert len(parts) == 1
 
 
-def test_parse_tabs():
+def test_parse_tabs() -> None:
     tab = '\t'
     string = utils.codeblock(
         f"""
@@ -870,6 +884,7 @@ def test_parse_tabs():
     self = parser.DoctestParser()
     parts = self.parse(string)
     doctest_part = parts[0]
+    assert isinstance(doctest_part, DoctestPart)
     assert tab in doctest_part.source
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,7 +25,10 @@ def test_final_eval_exec() -> None:
     if DEBUG:
         print(string)
         print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'exec',
+        'eval',
+    ]
 
     string = utils.codeblock(
         """
@@ -38,7 +41,9 @@ def test_final_eval_exec() -> None:
     if DEBUG:
         print(string)
         print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'exec'
+    ]
 
     string = utils.codeblock(
         r'''
@@ -55,7 +60,10 @@ def test_final_eval_exec() -> None:
     if DEBUG:
         print(string)
         print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'single']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'exec',
+        'single',
+    ]
 
     string = utils.codeblock(
         r"""
@@ -69,7 +77,10 @@ def test_final_eval_exec() -> None:
     if DEBUG:
         print(string)
         print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'exec',
+        'eval',
+    ]
 
     string = utils.codeblock(
         r"""
@@ -83,7 +94,9 @@ def test_final_eval_exec() -> None:
     if DEBUG:
         print(string)
         print([p.compile_mode for p in parts if isinstance(p, DoctestPart)])
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['single']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'single'
+    ]
 
 
 def test_compile_mode_print() -> None:
@@ -97,7 +110,10 @@ def test_compile_mode_print() -> None:
     )
     self = parser.DoctestParser()
     parts = self.parse(string)
-    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == ['exec', 'eval']
+    assert [p.compile_mode for p in parts if isinstance(p, DoctestPart)] == [
+        'exec',
+        'eval',
+    ]
 
 
 def test_label_lines() -> None:
@@ -392,7 +408,7 @@ def test_parse_comment() -> None:
 def test_parse_comment_with_inconsistent_indent() -> None:
     """Comments that ignore indentation should still parse."""
     string = utils.codeblock(
-        '''
+        """
         >>> class MyClass:
         >>> # comment separating members
         >>>     def method1(self):
@@ -402,7 +418,7 @@ def test_parse_comment_with_inconsistent_indent() -> None:
         >>>         ...
         >>> # end comment
         >>> self = MyClass()
-        '''
+        """
     )
     self = parser.DoctestParser()
     source_lines = string.split('\n')[:]
@@ -412,14 +428,16 @@ def test_parse_comment_with_inconsistent_indent() -> None:
     parts_: list[DoctestPart | str] = self.parse(string)
     parts: list[DoctestPart] = [p for p in parts_ if not isinstance(p, str)]
     # Ensure the comment lines were preserved in the resulting doctest part
-    assert any('# comment' in '\n'.join(cast(List[str], part.orig_lines))
-               for part in parts)
+    assert any(
+        '# comment' in '\n'.join(cast(List[str], part.orig_lines))
+        for part in parts
+    )
 
 
 def test_parse_comment_with_blank_lines_and_varying_indent() -> None:
     """Handle comment separators that include blank lines between blocks."""
     string = utils.codeblock(
-        '''
+        """
         >>> class WeirdSpacing:
         >>> # first separator
         >>>
@@ -435,7 +453,7 @@ def test_parse_comment_with_blank_lines_and_varying_indent() -> None:
         >>> # trailing separator
         >>>
         >>> weird = WeirdSpacing()
-        '''
+        """
     )
     self = parser.DoctestParser()
     source_lines = string.split('\n')[:]
@@ -444,17 +462,22 @@ def test_parse_comment_with_blank_lines_and_varying_indent() -> None:
     assert mode_hint == 'exec'
     parts_: list[DoctestPart | str] = self.parse(string)
     parts: list[DoctestPart] = [p for p in parts_ if not isinstance(p, str)]
-    combined = '\n'.join('\n'.join(cast(List[str], part.orig_lines))
-                         for part in parts)
-    for text in ['# first separator', '# second separator',
-                 '# nested separator', '# trailing separator']:
+    combined = '\n'.join(
+        '\n'.join(cast(List[str], part.orig_lines)) for part in parts
+    )
+    for text in [
+        '# first separator',
+        '# second separator',
+        '# nested separator',
+        '# trailing separator',
+    ]:
         assert text in combined
 
 
 def test_parse_comment_with_mixed_indentation_levels() -> None:
     """Comments should be tolerated even as indentation changes."""
     string = utils.codeblock(
-        '''
+        """
         >>> class Outer:
         >>> # before inner class
         >>>     class Inner:
@@ -467,7 +490,7 @@ def test_parse_comment_with_mixed_indentation_levels() -> None:
         >>>             ...
         >>> # after all class blocks
         >>> helper = Outer.Inner()
-        '''
+        """
     )
     self = parser.DoctestParser()
     source_lines = string.split('\n')[:]
@@ -476,10 +499,15 @@ def test_parse_comment_with_mixed_indentation_levels() -> None:
     assert mode_hint == 'exec'
     parts_: list[DoctestPart | str] = self.parse(string)
     parts: list[DoctestPart] = [p for p in parts_ if not isinstance(p, str)]
-    combined = '\n'.join('\n'.join(cast(List[str], part.orig_lines))
-                         for part in parts)
-    for text in ['# before inner class', '# inner comment missing indent',
-                 '# properly indented comment', '# after all class blocks']:
+    combined = '\n'.join(
+        '\n'.join(cast(List[str], part.orig_lines)) for part in parts
+    )
+    for text in [
+        '# before inner class',
+        '# inner comment missing indent',
+        '# properly indented comment',
+        '# after all class blocks',
+    ]:
         assert text in combined
 
 
@@ -549,7 +577,7 @@ def test_nonbalanced_statement() -> None:
     self = parser.DoctestParser()
     with pytest.raises(exceptions.DoctestParseError) as exc_info:
         self.parse(string)
-    ex : exceptions.DoctestParseError = exc_info.value
+    ex: exceptions.DoctestParseError = exc_info.value
     orig_ex = ex.orig_ex
     assert isinstance(orig_ex, exceptions.IncompleteParseError)
     msg = orig_ex.msg.lower()
@@ -572,7 +600,7 @@ def test_bad_indent() -> None:
     self = parser.DoctestParser()
     with pytest.raises(exceptions.DoctestParseError) as exc_info:
         self.parse(string)
-    ex : exceptions.DoctestParseError = exc_info.value
+    ex: exceptions.DoctestParseError = exc_info.value
     orig_ex = ex.orig_ex
     assert isinstance(orig_ex, SyntaxError), repr(type(orig_ex))
     msg = orig_ex.msg.lower()
@@ -606,7 +634,10 @@ def test_repl_twoline() -> None:
     )
     self = parser.DoctestParser(simulate_repl=True)
     parts = self.parse(string)
-    assert [p.source for p in parts if isinstance(p, DoctestPart)] == ['x = 1', 'x = 2']
+    assert [p.source for p in parts if isinstance(p, DoctestPart)] == [
+        'x = 1',
+        'x = 2',
+    ]
 
 
 def test_repl_comment_in_string() -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,9 @@
-import pytest
 from typing import List, cast
-from xdoctest.doctest_part import DoctestPart
+
+import pytest
+
 from xdoctest import exceptions, parser, utils
+from xdoctest.doctest_part import DoctestPart
 
 
 def test_final_eval_exec() -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,6 +9,7 @@ import sys
 
 import _pytest._code
 import pytest
+from pathlib import Path
 
 from xdoctest import utils
 from xdoctest.plugin import XDoctestItem, XDoctestModule, XDoctestTextfile
@@ -480,7 +481,7 @@ class TestXDoctest:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_property_lineno -v -s
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source(
                 utils.codeblock(
                     """
@@ -517,7 +518,7 @@ class TestXDoctest:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_property_lineno_freeform -v -s
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source(
                 utils.codeblock(
                     """
@@ -559,7 +560,7 @@ class TestXDoctest:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_property_lineno_google -v -s
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source(
                 utils.codeblock(
                     """
@@ -604,7 +605,7 @@ class TestXDoctest:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_property_lineno_google_v2 -v -s
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source(
                 utils.codeblock(
                     """
@@ -727,7 +728,7 @@ class TestXDoctest:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unex_importerror_with_module
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source("""
             import asdalsdkjaslkdjasd
         """)
@@ -787,7 +788,7 @@ class TestXDoctest:
             >>> self.test_doctestmodule_external_and_issue116(testdir)
         """
         p = testdir.mkpydir('hello_2')
-        p.join('__init__.py').write(
+        p.join(Path('__init__.py')).write(
             _pytest._code.Source("""
             def somefunc():
                 '''
@@ -1854,7 +1855,7 @@ class Disabled:
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_linedata_missing
         """
-        testdir.tmpdir.join('hello.py').write(
+        testdir.tmpdir.join(Path('hello.py')).write(
             _pytest._code.Source("""
             class Fun:
                 @property

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -37,7 +37,7 @@ OLD_TEXT_ARGS = ['--xdoc-glob=*.txt']
 #         file.write(str(text) + '\n')
 
 
-def explicit_testdir():
+def explicit_testdir() -> None:
     r"""
     Explicitly constructs a testdir for use in IPython development
     Note used by any tests.
@@ -80,20 +80,20 @@ def explicit_testdir():
     # _pytest.config._preloadplugins()  # to populate pytest.* namespace so help(pytest) works
     import _pytest
 
-    config = _pytest.config._prepareconfig(['-s'], plugins=['pytester'])
-    session = _pytest.main.Session(config)
+    config = _pytest.config._prepareconfig(['-s'], plugins=['pytester'])    # type: ignore
+    session = _pytest.main.Session(config)    # type: ignore
 
-    _pytest.tmpdir.pytest_configure(config)
-    _pytest.fixtures.pytest_sessionstart(session)
-    _pytest.runner.pytest_sessionstart(session)
+    _pytest.tmpdir.pytest_configure(config)  # type: ignore
+    _pytest.fixtures.pytest_sessionstart(session)  # type: ignore
+    _pytest.runner.pytest_sessionstart(session)  # type: ignore
 
-    def func(testdir):
+    def func(testdir) -> None:
         pass
 
-    parent = _pytest.python.Module(
+    parent = _pytest.python.Module(    # type: ignore
         'parent', config=config, session=session, nodeid='myparent'
     )
-    function = _pytest.python.Function(
+    function = _pytest.python.Function(    # type: ignore
         'func',
         parent,
         callobj=func,
@@ -141,7 +141,7 @@ class TestXDoctestActivation:
             ('--doctest-modules --xdoctest', True),
         ],
     )
-    def test_xdoctest_cli_activation(self, request, flags, load):
+    def test_xdoctest_cli_activation(self, request, flags, load) -> None:
         """
         Activate `xdoctest` via command-line arguments.
 
@@ -151,7 +151,7 @@ test_xdoctest_cli_activation
         """
         self._check_activation(request, flags, load)
 
-    def test_xdoctest_config_activation(self, request):
+    def test_xdoctest_config_activation(self, request) -> None:
         """
         Activate `xdoctest` via config file.
 
@@ -165,7 +165,7 @@ test_xdoctest_config_activation
         """)
         self._check_activation(request, '', True)
 
-    def test_xdoctest_explicit_suppression(self, request):
+    def test_xdoctest_explicit_suppression(self, request) -> None:
         """
         Deactivate `xdoctest` via explicitly unloading the plugin on the
         command line.
@@ -184,7 +184,7 @@ test_xdoctest_explicit_suppression
             pdt_namespace_after = self._get_pytest_doctest_module_dict()
             assert pdt_namespace_before == pdt_namespace_after
 
-    def _check_activation(self, request, flags, load):
+    def _check_activation(self, request, flags, load) -> None:
         """
         Check that if :py:mod:`xdoctest.plugin` is ``load``-ed,
         :py:mod:`_pytest.doctest` is unloaded but otherwise untouched.
@@ -223,7 +223,7 @@ test_xdoctest_explicit_suppression
 
 
 class TestXDoctest:
-    def test_collect_testtextfile(self, testdir):
+    def test_collect_testtextfile(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_collect_testtextfile
@@ -249,7 +249,7 @@ class TestXDoctest:
         items, reprec = testdir.inline_genitems(w)
         assert len(items) == 0
 
-    def test_collect_module_empty(self, testdir):
+    def test_collect_module_empty(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_collect_module_empty
@@ -259,7 +259,7 @@ class TestXDoctest:
             items, reprec = testdir.inline_genitems(p, '--xdoctest-modules')
             assert len(items) == 0
 
-    def test_simple_doctestfile(self, testdir):
+    def test_simple_doctestfile(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_simple_doctestfile
@@ -280,7 +280,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, *(EXTRA_ARGS + OLD_TEXT_ARGS))
         reprec.assertoutcome(failed=1)
 
-    def test_new_pattern(self, testdir):
+    def test_new_pattern(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_new_pattern
@@ -297,7 +297,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(failed=1)
 
-    def test_multiple_patterns(self, testdir):
+    def test_multiple_patterns(self, testdir) -> None:
         """Test support for multiple --xdoctest-glob arguments (#1255).
 
         CommandLine:
@@ -349,7 +349,7 @@ class TestXDoctest:
             '   test_string,    encoding',
             [('foo', 'ascii'), ('öäü', 'latin1'), ('öäü', 'utf-8')],
         )
-        def test_encoding(self, testdir, test_string, encoding):
+        def test_encoding(self, testdir, test_string, encoding) -> None:
             """Test support for xdoctest_encoding ini option.
 
             CommandLine:
@@ -384,7 +384,7 @@ class TestXDoctest:
             '   test_string,    encoding',
             [('foo', 'ascii'), ('öäü', 'latin1'), ('öäü', 'utf-8')],
         )
-        def test_encoding(self, pytester, test_string, encoding):
+        def test_encoding(self, pytester, test_string, encoding) -> None:
             """Test support for doctest_encoding ini option."""
             pytester.makeini(
                 """
@@ -405,7 +405,7 @@ class TestXDoctest:
 
             result.stdout.fnmatch_lines(['*1 passed*'])
 
-    def test_xdoctest_options(self, testdir):
+    def test_xdoctest_options(self, testdir) -> None:
         """Test support for xdoctest_encoding ini option.
 
         CommandLine:
@@ -427,7 +427,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(skipped=1, failed=0, passed=0)
 
-    def test_doctest_unexpected_exception(self, testdir):
+    def test_doctest_unexpected_exception(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unexpected_exception
@@ -475,7 +475,7 @@ class TestXDoctest:
         #     "*FAILED*ZeroDivision*",
         # ])
 
-    def test_doctest_property_lineno(self, testdir):
+    def test_doctest_property_lineno(self, testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -512,7 +512,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_freeform(self, testdir):
+    def test_doctest_property_lineno_freeform(self, testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -554,7 +554,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google(self, testdir):
+    def test_doctest_property_lineno_google(self, testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -596,7 +596,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google_v2(self, testdir):
+    def test_doctest_property_lineno_google_v2(self, testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -640,7 +640,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_docstring_show_entire_doctest(self, testdir):
+    def test_docstring_show_entire_doctest(self, testdir) -> None:
         """Test that we show the entire doctest when there is a failure
 
         REPLACES: test_docstring_context_around_error
@@ -700,7 +700,7 @@ class TestXDoctest:
         assert 'Example:' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
 
-    def test_doctest_unex_importerror_only_txt(self, testdir):
+    def test_doctest_unex_importerror_only_txt(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unex_importerror_only_txt
@@ -721,7 +721,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_unex_importerror_with_module(self, testdir):
+    def test_doctest_unex_importerror_with_module(self, testdir) -> None:
         """
         CHANGES:
             No longer fails during collection because we're doing
@@ -760,7 +760,7 @@ class TestXDoctest:
         sys.path.pop()
 
     @pytest.mark.skip('pytest 3.7.0 broke this. Not sure why')
-    def test_doctestmodule_external_and_issue116(self, testdir):
+    def test_doctestmodule_external_and_issue116(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_external_and_issue116
@@ -816,7 +816,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_txtfile_failing(self, testdir):
+    def test_txtfile_failing(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_failing -s
@@ -843,7 +843,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_txtfile_with_fixtures(self, testdir):
+    def test_txtfile_with_fixtures(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_with_fixtures
@@ -858,7 +858,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_txtfile_with_usefixtures_in_ini(self, testdir):
+    def test_txtfile_with_usefixtures_in_ini(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_with_usefixtures_in_ini
@@ -884,7 +884,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_ignored_whitespace(self, testdir):
+    def test_ignored_whitespace(self, testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
@@ -901,7 +901,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(passed=1)
 
-    def test_ignored_whitespace_glob(self, testdir):
+    def test_ignored_whitespace_glob(self, testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
@@ -918,7 +918,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_contains_unicode(self, testdir):
+    def test_contains_unicode(self, testdir) -> None:
         """Fix internal error with docstrings containing non-ascii characters.
 
         pytest tests/test_plugin.py -k test_contains_unicode
@@ -939,7 +939,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_junit_report_for_doctest(self, testdir):
+    def test_junit_report_for_doctest(self, testdir) -> None:
         """
         #713: Fix --junit-xml option when used with --xdoctest-modules.
         """
@@ -956,7 +956,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(failed=1)
 
-    def test_unicode_doctest_module(self, testdir):
+    def test_unicode_doctest_module(self, testdir) -> None:
         """
         Test case for issue 2434: DecodeError on Python 2 when xdoctest docstring
         contains non-ascii characters.
@@ -978,7 +978,7 @@ class TestXDoctest:
         result = testdir.runpytest(p, '--xdoctest-modules', *EXTRA_ARGS)
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_multiline_list(self, testdir):
+    def test_xdoctest_multiline_list(self, testdir) -> None:
         """
         pytest tests/test_plugin.py -k test_xdoctest_multiline_list
         """
@@ -995,7 +995,7 @@ class TestXDoctest:
         result = testdir.runpytest(p, '--xdoctest-modules', *EXTRA_ARGS)
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_multiline_string(self, testdir):
+    def test_xdoctest_multiline_string(self, testdir) -> None:
         """
         pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_multiline_string
         """
@@ -1035,7 +1035,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_trycatch(self, testdir):
+    def test_xdoctest_trycatch(self, testdir) -> None:
         """
         CommandLine:
             pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_trycatch
@@ -1070,7 +1070,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_functions(self, testdir):
+    def test_xdoctest_functions(self, testdir) -> None:
         """
         CommandLine:
             pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_functions
@@ -1097,7 +1097,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_stdout_capture_no(self, testdir):
+    def test_stdout_capture_no(self, testdir) -> None:
         """
         Test for xdoctest#3
 
@@ -1127,7 +1127,7 @@ class TestXDoctest:
         result.stdout.fnmatch_lines(['in-doctest-print'])
         result.stdout.fnmatch_lines(['in-func-print'])
 
-    def test_stdout_capture_yes(self, testdir):
+    def test_stdout_capture_yes(self, testdir) -> None:
         """
         Test for xdoctest#3
 
@@ -1152,7 +1152,7 @@ class TestXDoctest:
 
 
 class TestXDoctestModuleLevel:
-    def test_doctestmodule(self, testdir):
+    def test_doctestmodule(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_doctestmodule
@@ -1177,7 +1177,7 @@ class TestXDoctestModuleLevel:
         # print(reprec.listoutcomes())
         reprec.assertoutcome(failed=1)
 
-    def test_collect_module_single_modulelevel_doctest(self, testdir):
+    def test_collect_module_single_modulelevel_doctest(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_single_modulelevel_doctest
@@ -1196,7 +1196,7 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0], XDoctestItem)
             assert isinstance(items[0].parent, XDoctestModule)
 
-    def test_collect_module_two_doctest_one_modulelevel(self, testdir):
+    def test_collect_module_two_doctest_one_modulelevel(self, testdir) -> None:
         path = testdir.makepyfile(
             whatever="""
             '>>> x = None'
@@ -1212,7 +1212,7 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0].parent, XDoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_collect_module_two_doctest_no_modulelevel(self, testdir):
+    def test_collect_module_two_doctest_no_modulelevel(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_two_doctest_no_modulelevel
@@ -1255,7 +1255,7 @@ class TestXDoctestModuleLevel:
 class TestLiterals:
     @pytest.mark.parametrize('config_mode', ['ini', 'comment'])
     @pytest.mark.skip('bytes are not supported yet')
-    def test_allow_unicode(self, testdir, config_mode):
+    def test_allow_unicode(self, testdir, config_mode) -> None:
         """Test that doctests which output unicode work in all python versions
         tested by pytest when the ALLOW_UNICODE option is used (either in
         the ini file or by an inline comment).
@@ -1291,7 +1291,7 @@ class TestLiterals:
 
     @pytest.mark.parametrize('config_mode', ['ini', 'comment'])
     @pytest.mark.skip('bytes are not supported yet')
-    def test_allow_bytes(self, testdir, config_mode):
+    def test_allow_bytes(self, testdir, config_mode) -> None:
         """Test that doctests which output bytes work in all python versions
         tested by pytest when the ALLOW_BYTES option is used (either in
         the ini file or by an inline comment)(#1287).
@@ -1326,7 +1326,7 @@ class TestLiterals:
         reprec.assertoutcome(passed=2)
 
     @pytest.mark.skip('bytes are not supported yet')
-    def test_unicode_string(self, testdir):
+    def test_unicode_string(self, testdir) -> None:
         """Test that doctests which output unicode fail in Python 2 when
         the ALLOW_UNICODE option is not used. The same test should pass
         in Python 3.
@@ -1344,7 +1344,7 @@ class TestLiterals:
         reprec.assertoutcome(passed=passed, failed=int(not passed))
 
     @pytest.mark.skip('bytes are not supported yet')
-    def test_bytes_literal(self, testdir):
+    def test_bytes_literal(self, testdir) -> None:
         """Test that doctests which output bytes fail in Python 3 when
         the ALLOW_BYTES option is not used. The same test should pass
         in Python 2 (#1287).
@@ -1371,7 +1371,7 @@ class TestXDoctestSkips:
         pytest tests/test_plugin.py::TestXDoctestSkips
     """
 
-    def test_xdoctest_skips_diabled(self, testdir):
+    def test_xdoctest_skips_diabled(self, testdir) -> None:
         testdir.makepyfile(
             foo="""
             import sys
@@ -1393,7 +1393,7 @@ class TestXDoctestSkips:
 
     @pytest.fixture(params=['text', 'module'])
     def makedoctest(self, testdir, request):
-        def makeit(xdoctest):
+        def makeit(xdoctest) -> None:
             mode = request.param
             if mode == 'text':
                 testdir.maketxtfile(xdoctest)
@@ -1403,7 +1403,7 @@ class TestXDoctestSkips:
 
         return makeit
 
-    def test_one_skipped_passed(self, testdir, makedoctest):
+    def test_one_skipped_passed(self, testdir, makedoctest) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_one_skipped_passed
@@ -1419,7 +1419,7 @@ class TestXDoctestSkips:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_one_skipped_failed(self, testdir, makedoctest):
+    def test_one_skipped_failed(self, testdir, makedoctest) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_one_skipped_failed
@@ -1435,7 +1435,7 @@ class TestXDoctestSkips:
         )
         reprec.assertoutcome(failed=1)
 
-    def test_all_skipped(self, testdir, makedoctest):
+    def test_all_skipped(self, testdir, makedoctest) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_all_skipped
@@ -1454,7 +1454,7 @@ class TestXDoctestSkips:
         # is the case here.
         reprec.assertoutcome(passed=0, skipped=1)
 
-    def test_all_skipped_global(self, testdir, makedoctest):
+    def test_all_skipped_global(self, testdir, makedoctest) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_all_skipped_global
@@ -1472,7 +1472,7 @@ class TestXDoctestSkips:
         )
         reprec.assertoutcome(passed=0, skipped=1)
 
-    def test_vacuous_all_skipped(self, testdir, makedoctest):
+    def test_vacuous_all_skipped(self, testdir, makedoctest) -> None:
         makedoctest('')
         reprec = testdir.inline_run('--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(passed=0, skipped=0)
@@ -1481,7 +1481,7 @@ class TestXDoctestSkips:
 class TestXDoctestAutoUseFixtures:
     SCOPES = ['module', 'session', 'class', 'function']
 
-    def test_doctest_module_session_fixture(self, testdir):
+    def test_doctest_module_session_fixture(self, testdir) -> None:
         """
         Test that session fixtures are initialized for xdoctest modules (#768)
 
@@ -1522,7 +1522,7 @@ class TestXDoctestAutoUseFixtures:
 
     @pytest.mark.parametrize('scope', SCOPES)
     @pytest.mark.parametrize('enable_doctest', [True, False])
-    def test_fixture_scopes(self, testdir, scope, enable_doctest):
+    def test_fixture_scopes(self, testdir, scope, enable_doctest) -> None:
         """Test that auto-use fixtures work properly with xdoctest modules.
         See #1057 and #1100.
 
@@ -1559,7 +1559,7 @@ class TestXDoctestAutoUseFixtures:
     @pytest.mark.parametrize('use_fixture_in_doctest', [True, False])
     def test_fixture_module_doctest_scopes(
         self, testdir, scope, autouse, use_fixture_in_doctest
-    ):
+    ) -> None:
         """Test that auto-use fixtures work properly with xdoctest files.
         See #1057 and #1100.
 
@@ -1595,7 +1595,7 @@ class TestXDoctestAutoUseFixtures:
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_auto_use_request_attributes(self, testdir, scope):
+    def test_auto_use_request_attributes(self, testdir, scope) -> None:
         """Check that all attributes of a request in an autouse fixture
         behave as expected when requested for a xdoctest item.
         """
@@ -1641,7 +1641,7 @@ class TestXDoctestNamespaceFixture:
     SCOPES = ['module', 'session', 'class', 'function']
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_doctestfile(self, testdir, scope):
+    def test_namespace_doctestfile(self, testdir, scope) -> None:
         """
         Check that inserting something into the namespace works in a
         simple text file xdoctest
@@ -1666,7 +1666,7 @@ class TestXDoctestNamespaceFixture:
         reprec.assertoutcome(passed=1)
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_pyfile(self, testdir, scope):
+    def test_namespace_pyfile(self, testdir, scope) -> None:
         """
         Check that inserting something into the namespace works in a
         simple Python file docstring xdoctest
@@ -1716,7 +1716,7 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['udiff', 'UDIFF', 'uDiFf'])
-    def test_doctest_report_udiff(self, testdir, format):
+    def test_doctest_report_udiff(self, testdir, format) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_udiff
         """
@@ -1730,7 +1730,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_cdiff(self, testdir):
+    def test_doctest_report_cdiff(self, testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_cdiff
         """
@@ -1749,7 +1749,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_ndiff(self, testdir):
+    def test_doctest_report_ndiff(self, testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_ndiff
         """
@@ -1767,7 +1767,7 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['none', 'only_first_failure'])
-    def test_doctest_report_none_or_only_first_failure(self, testdir, format):
+    def test_doctest_report_none_or_only_first_failure(self, testdir, format) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_none_or_only_first_failure
         """
@@ -1787,7 +1787,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_invalid(self, testdir):
+    def test_doctest_report_invalid(self, testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_invalid
         """
@@ -1800,7 +1800,7 @@ class TestXDoctestReportingOption:
 
 
 class Disabled:
-    def test_docstring_context_around_error(self, testdir):
+    def test_docstring_context_around_error(self, testdir) -> None:
         """Test that we show some context before the actual line of a failing
         xdoctest.
 
@@ -1847,7 +1847,7 @@ class Disabled:
         assert 'text-line-2' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
 
-    def test_doctest_linedata_missing(self, testdir):
+    def test_doctest_linedata_missing(self, testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -1877,7 +1877,7 @@ class Disabled:
             ]
         )
 
-    def test_doctestmodule_with_fixtures(self, testdir):
+    def test_doctestmodule_with_fixtures(self, testdir) -> None:
         p = testdir.makepyfile("""
             '''
                 >>> dir = getfixture('tmpdir')
@@ -1888,7 +1888,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(passed=1)
 
-    def test_doctestmodule_three_tests(self, testdir):
+    def test_doctestmodule_three_tests(self, testdir) -> None:
         p = testdir.makepyfile("""
             '''
             >>> dir = getfixture('tmpdir')
@@ -1913,7 +1913,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(passed=3)
 
-    def test_doctestmodule_two_tests_one_fail(self, testdir):
+    def test_doctestmodule_two_tests_one_fail(self, testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_two_tests_one_fail
@@ -1936,7 +1936,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(failed=1, passed=1)
 
-    def test_non_ignored_whitespace(self, testdir):
+    def test_non_ignored_whitespace(self, testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS
@@ -1953,7 +1953,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_non_ignored_whitespace_glob(self, testdir):
+    def test_non_ignored_whitespace_glob(self, testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS
@@ -1970,7 +1970,7 @@ class Disabled:
         )
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_ignore_import_errors_on_doctest(self, testdir):
+    def test_ignore_import_errors_on_doctest(self, testdir) -> None:
         p = testdir.makepyfile("""
             import asdf
 
@@ -1987,7 +1987,7 @@ class Disabled:
         )
         reprec.assertoutcome(skipped=1, failed=1, passed=0)
 
-    def test_unicode_doctest(self, testdir):
+    def test_unicode_doctest(self, testdir) -> None:
         """
         Test case for issue 2434: DecodeError on Python 2 when xdoctest contains non-ascii
         characters.
@@ -2015,7 +2015,7 @@ class Disabled:
             ]
         )
 
-    def test_reportinfo(self, testdir):
+    def test_reportinfo(self, testdir) -> None:
         """
         Test case to make sure that XDoctestItem.reportinfo() returns lineno.
         """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1389,7 +1389,7 @@ class TestXDoctestSkips:
             result.stdout.fnmatch_lines(['*no tests ran*'])
 
     @pytest.fixture(params=['text', 'module'])
-    def makedoctest(self, testdir, request) -> None:
+    def makedoctest(self, testdir, request):
         def makeit(xdoctest) -> None:
             mode = request.param
             if mode == 'text':

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -87,7 +87,7 @@ def explicit_testdir() -> object:
     _pytest.fixtures.pytest_sessionstart(session)  # type: ignore
     _pytest.runner.pytest_sessionstart(session)  # type: ignore
 
-    def func(testdir) -> None:
+    def func(testdir: pytest.Testdir) -> None:
         pass
 
     parent = _pytest.python.Module(  # type: ignore
@@ -141,7 +141,7 @@ class TestXDoctestActivation:
             ('--doctest-modules --xdoctest', True),
         ],
     )
-    def test_xdoctest_cli_activation(self, request, flags, load) -> None:
+    def test_xdoctest_cli_activation(self, request, flags: str, load: bool) -> None:
         """
         Activate `xdoctest` via command-line arguments.
 
@@ -220,7 +220,7 @@ class TestXDoctestActivation:
 
 
 class TestXDoctest:
-    def test_collect_testtextfile(self, testdir) -> None:
+    def test_collect_testtextfile(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_collect_testtextfile
@@ -246,7 +246,7 @@ class TestXDoctest:
         items, reprec = testdir.inline_genitems(w)
         assert len(items) == 0
 
-    def test_collect_module_empty(self, testdir) -> None:
+    def test_collect_module_empty(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_collect_module_empty
@@ -256,7 +256,7 @@ class TestXDoctest:
             items, reprec = testdir.inline_genitems(p, '--xdoctest-modules')
             assert len(items) == 0
 
-    def test_simple_doctestfile(self, testdir) -> None:
+    def test_simple_doctestfile(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_simple_doctestfile
@@ -277,7 +277,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, *(EXTRA_ARGS + OLD_TEXT_ARGS))
         reprec.assertoutcome(failed=1)
 
-    def test_new_pattern(self, testdir) -> None:
+    def test_new_pattern(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_new_pattern
@@ -294,7 +294,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(failed=1)
 
-    def test_multiple_patterns(self, testdir) -> None:
+    def test_multiple_patterns(self, testdir: pytest.Testdir) -> None:
         """Test support for multiple --xdoctest-glob arguments (#1255).
 
         CommandLine:
@@ -402,7 +402,7 @@ class TestXDoctest:
 
             result.stdout.fnmatch_lines(['*1 passed*'])
 
-    def test_xdoctest_options(self, testdir) -> None:
+    def test_xdoctest_options(self, testdir: pytest.Testdir) -> None:
         """Test support for xdoctest_encoding ini option.
 
         CommandLine:
@@ -424,7 +424,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(skipped=1, failed=0, passed=0)
 
-    def test_doctest_unexpected_exception(self, testdir) -> None:
+    def test_doctest_unexpected_exception(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unexpected_exception
@@ -472,7 +472,7 @@ class TestXDoctest:
         #     "*FAILED*ZeroDivision*",
         # ])
 
-    def test_doctest_property_lineno(self, testdir) -> None:
+    def test_doctest_property_lineno(self, testdir: pytest.Testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -509,7 +509,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_freeform(self, testdir) -> None:
+    def test_doctest_property_lineno_freeform(self, testdir: pytest.Testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -551,7 +551,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google(self, testdir) -> None:
+    def test_doctest_property_lineno_google(self, testdir: pytest.Testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -593,7 +593,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google_v2(self, testdir) -> None:
+    def test_doctest_property_lineno_google_v2(self, testdir: pytest.Testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -637,7 +637,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_docstring_show_entire_doctest(self, testdir) -> None:
+    def test_docstring_show_entire_doctest(self, testdir: pytest.Testdir) -> None:
         """Test that we show the entire doctest when there is a failure
 
         REPLACES: test_docstring_context_around_error
@@ -697,7 +697,7 @@ class TestXDoctest:
         assert 'Example:' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
 
-    def test_doctest_unex_importerror_only_txt(self, testdir) -> None:
+    def test_doctest_unex_importerror_only_txt(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unex_importerror_only_txt
@@ -718,7 +718,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_unex_importerror_with_module(self, testdir) -> None:
+    def test_doctest_unex_importerror_with_module(self, testdir: pytest.Testdir) -> None:
         """
         CHANGES:
             No longer fails during collection because we're doing
@@ -757,7 +757,7 @@ class TestXDoctest:
         sys.path.pop()
 
     @pytest.mark.skip('pytest 3.7.0 broke this. Not sure why')
-    def test_doctestmodule_external_and_issue116(self, testdir) -> None:
+    def test_doctestmodule_external_and_issue116(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_external_and_issue116
@@ -813,7 +813,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_txtfile_failing(self, testdir) -> None:
+    def test_txtfile_failing(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_failing -s
@@ -840,7 +840,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_txtfile_with_fixtures(self, testdir) -> None:
+    def test_txtfile_with_fixtures(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_with_fixtures
@@ -855,7 +855,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_txtfile_with_usefixtures_in_ini(self, testdir) -> None:
+    def test_txtfile_with_usefixtures_in_ini(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_with_usefixtures_in_ini
@@ -881,7 +881,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_ignored_whitespace(self, testdir) -> None:
+    def test_ignored_whitespace(self, testdir: pytest.Testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
@@ -898,7 +898,7 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(passed=1)
 
-    def test_ignored_whitespace_glob(self, testdir) -> None:
+    def test_ignored_whitespace_glob(self, testdir: pytest.Testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
@@ -915,7 +915,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_contains_unicode(self, testdir) -> None:
+    def test_contains_unicode(self, testdir: pytest.Testdir) -> None:
         """Fix internal error with docstrings containing non-ascii characters.
 
         pytest tests/test_plugin.py -k test_contains_unicode
@@ -936,7 +936,7 @@ class TestXDoctest:
             ]
         )
 
-    def test_junit_report_for_doctest(self, testdir) -> None:
+    def test_junit_report_for_doctest(self, testdir: pytest.Testdir) -> None:
         """
         #713: Fix --junit-xml option when used with --xdoctest-modules.
         """
@@ -953,7 +953,7 @@ class TestXDoctest:
         )
         reprec.assertoutcome(failed=1)
 
-    def test_unicode_doctest_module(self, testdir) -> None:
+    def test_unicode_doctest_module(self, testdir: pytest.Testdir) -> None:
         """
         Test case for issue 2434: DecodeError on Python 2 when xdoctest docstring
         contains non-ascii characters.
@@ -975,7 +975,7 @@ class TestXDoctest:
         result = testdir.runpytest(p, '--xdoctest-modules', *EXTRA_ARGS)
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_multiline_list(self, testdir) -> None:
+    def test_xdoctest_multiline_list(self, testdir: pytest.Testdir) -> None:
         """
         pytest tests/test_plugin.py -k test_xdoctest_multiline_list
         """
@@ -992,7 +992,7 @@ class TestXDoctest:
         result = testdir.runpytest(p, '--xdoctest-modules', *EXTRA_ARGS)
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_multiline_string(self, testdir) -> None:
+    def test_xdoctest_multiline_string(self, testdir: pytest.Testdir) -> None:
         """
         pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_multiline_string
         """
@@ -1032,7 +1032,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_trycatch(self, testdir) -> None:
+    def test_xdoctest_trycatch(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_trycatch
@@ -1067,7 +1067,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_xdoctest_functions(self, testdir) -> None:
+    def test_xdoctest_functions(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest -rsxX -p pytester tests/test_plugin.py::TestXDoctest::test_xdoctest_functions
@@ -1094,7 +1094,7 @@ class TestXDoctest:
         )
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
-    def test_stdout_capture_no(self, testdir) -> None:
+    def test_stdout_capture_no(self, testdir: pytest.Testdir) -> None:
         """
         Test for xdoctest#3
 
@@ -1124,7 +1124,7 @@ class TestXDoctest:
         result.stdout.fnmatch_lines(['in-doctest-print'])
         result.stdout.fnmatch_lines(['in-func-print'])
 
-    def test_stdout_capture_yes(self, testdir) -> None:
+    def test_stdout_capture_yes(self, testdir: pytest.Testdir) -> None:
         """
         Test for xdoctest#3
 
@@ -1149,7 +1149,7 @@ class TestXDoctest:
 
 
 class TestXDoctestModuleLevel:
-    def test_doctestmodule(self, testdir) -> None:
+    def test_doctestmodule(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_doctestmodule
@@ -1174,7 +1174,7 @@ class TestXDoctestModuleLevel:
         # print(reprec.listoutcomes())
         reprec.assertoutcome(failed=1)
 
-    def test_collect_module_single_modulelevel_doctest(self, testdir) -> None:
+    def test_collect_module_single_modulelevel_doctest(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_single_modulelevel_doctest
@@ -1193,7 +1193,7 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0], XDoctestItem)
             assert isinstance(items[0].parent, XDoctestModule)
 
-    def test_collect_module_two_doctest_one_modulelevel(self, testdir) -> None:
+    def test_collect_module_two_doctest_one_modulelevel(self, testdir: pytest.Testdir) -> None:
         path = testdir.makepyfile(
             whatever="""
             '>>> x = None'
@@ -1209,7 +1209,7 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0].parent, XDoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_collect_module_two_doctest_no_modulelevel(self, testdir) -> None:
+    def test_collect_module_two_doctest_no_modulelevel(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_two_doctest_no_modulelevel
@@ -1323,7 +1323,7 @@ class TestLiterals:
         reprec.assertoutcome(passed=2)
 
     @pytest.mark.skip('bytes are not supported yet')
-    def test_unicode_string(self, testdir) -> None:
+    def test_unicode_string(self, testdir: pytest.Testdir) -> None:
         """Test that doctests which output unicode fail in Python 2 when
         the ALLOW_UNICODE option is not used. The same test should pass
         in Python 3.
@@ -1341,7 +1341,7 @@ class TestLiterals:
         reprec.assertoutcome(passed=passed, failed=int(not passed))
 
     @pytest.mark.skip('bytes are not supported yet')
-    def test_bytes_literal(self, testdir) -> None:
+    def test_bytes_literal(self, testdir: pytest.Testdir) -> None:
         """Test that doctests which output bytes fail in Python 3 when
         the ALLOW_BYTES option is not used. The same test should pass
         in Python 2 (#1287).
@@ -1368,7 +1368,7 @@ class TestXDoctestSkips:
         pytest tests/test_plugin.py::TestXDoctestSkips
     """
 
-    def test_xdoctest_skips_diabled(self, testdir) -> None:
+    def test_xdoctest_skips_diabled(self, testdir: pytest.Testdir) -> None:
         testdir.makepyfile(
             foo="""
             import sys
@@ -1451,7 +1451,7 @@ class TestXDoctestSkips:
         # is the case here.
         reprec.assertoutcome(passed=0, skipped=1)
 
-    def test_all_skipped_global(self, testdir, makedoctest) -> None:
+    def test_all_skipped_global(self, testdir: pytest.Testdir, makedoctest) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_all_skipped_global
@@ -1478,7 +1478,7 @@ class TestXDoctestSkips:
 class TestXDoctestAutoUseFixtures:
     SCOPES = ['module', 'session', 'class', 'function']
 
-    def test_doctest_module_session_fixture(self, testdir) -> None:
+    def test_doctest_module_session_fixture(self, testdir: pytest.Testdir) -> None:
         """
         Test that session fixtures are initialized for xdoctest modules (#768)
 
@@ -1592,7 +1592,7 @@ class TestXDoctestAutoUseFixtures:
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_auto_use_request_attributes(self, testdir, scope) -> None:
+    def test_auto_use_request_attributes(self, testdir: pytest.Testdir, scope: str) -> None:
         """Check that all attributes of a request in an autouse fixture
         behave as expected when requested for a xdoctest item.
         """
@@ -1638,7 +1638,7 @@ class TestXDoctestNamespaceFixture:
     SCOPES = ['module', 'session', 'class', 'function']
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_doctestfile(self, testdir, scope) -> None:
+    def test_namespace_doctestfile(self, testdir: pytest.Testdir, scope: str) -> None:
         """
         Check that inserting something into the namespace works in a
         simple text file xdoctest
@@ -1663,7 +1663,7 @@ class TestXDoctestNamespaceFixture:
         reprec.assertoutcome(passed=1)
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_pyfile(self, testdir, scope) -> None:
+    def test_namespace_pyfile(self, testdir: pytest.Testdir, scope: str) -> None:
         """
         Check that inserting something into the namespace works in a
         simple Python file docstring xdoctest
@@ -1692,7 +1692,7 @@ class TestXDoctestNamespaceFixture:
 
 
 class TestXDoctestReportingOption:
-    def _run_doctest_report(self, testdir, format):
+    def _run_doctest_report(self, testdir: pytest.Testdir, format: str):
         testdir.makepyfile("""
             def foo():
                 '''
@@ -1713,7 +1713,7 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['udiff', 'UDIFF', 'uDiFf'])
-    def test_doctest_report_udiff(self, testdir, format) -> None:
+    def test_doctest_report_udiff(self, testdir: pytest.Testdir, format: str) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_udiff
         """
@@ -1727,7 +1727,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_cdiff(self, testdir) -> None:
+    def test_doctest_report_cdiff(self, testdir: pytest.Testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_cdiff
         """
@@ -1746,7 +1746,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_ndiff(self, testdir) -> None:
+    def test_doctest_report_ndiff(self, testdir: pytest.Testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_ndiff
         """
@@ -1764,8 +1764,8 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['none', 'only_first_failure'])
-    def test_doctest_report_none_or_only_first_failure(
-        self, testdir, format
+    def test_doctst_report_neone_or_only_first_failure(
+        self, testdir: pytest.Testdir, format: str
     ) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_none_or_only_first_failure
@@ -1786,7 +1786,7 @@ class TestXDoctestReportingOption:
             ]
         )
 
-    def test_doctest_report_invalid(self, testdir) -> None:
+    def test_doctest_report_invalid(self, testdir: pytest.Testdir) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_invalid
         """
@@ -1799,7 +1799,7 @@ class TestXDoctestReportingOption:
 
 
 class Disabled:
-    def test_docstring_context_around_error(self, testdir) -> None:
+    def test_docstring_context_around_error(self, testdir: pytest.Testdir) -> None:
         """Test that we show some context before the actual line of a failing
         xdoctest.
 
@@ -1846,7 +1846,7 @@ class Disabled:
         assert 'text-line-2' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
 
-    def test_doctest_linedata_missing(self, testdir) -> None:
+    def test_doctest_linedata_missing(self, testdir: pytest.Testdir) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -1876,7 +1876,7 @@ class Disabled:
             ]
         )
 
-    def test_doctestmodule_with_fixtures(self, testdir) -> None:
+    def test_doctestmodule_with_fixtures(self, testdir: pytest.Testdir) -> None:
         p = testdir.makepyfile("""
             '''
                 >>> dir = getfixture('tmpdir')
@@ -1887,7 +1887,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(passed=1)
 
-    def test_doctestmodule_three_tests(self, testdir) -> None:
+    def test_doctestmodule_three_tests(self, testdir: pytest.Testdir) -> None:
         p = testdir.makepyfile("""
             '''
             >>> dir = getfixture('tmpdir')
@@ -1912,7 +1912,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(passed=3)
 
-    def test_doctestmodule_two_tests_one_fail(self, testdir) -> None:
+    def test_doctestmodule_two_tests_one_fail(self, testdir: pytest.Testdir) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_two_tests_one_fail
@@ -1935,7 +1935,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(failed=1, passed=1)
 
-    def test_non_ignored_whitespace(self, testdir) -> None:
+    def test_non_ignored_whitespace(self, testdir: pytest.Testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS
@@ -1952,7 +1952,7 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_non_ignored_whitespace_glob(self, testdir) -> None:
+    def test_non_ignored_whitespace_glob(self, testdir: pytest.Testdir) -> None:
         testdir.makeini("""
             [pytest]
             doctest_optionflags = ELLIPSIS
@@ -1969,7 +1969,7 @@ class Disabled:
         )
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_ignore_import_errors_on_doctest(self, testdir) -> None:
+    def test_ignore_import_errors_on_doctest(self, testdir: pytest.Testdir) -> None:
         p = testdir.makepyfile("""
             import asdf
 
@@ -1986,7 +1986,7 @@ class Disabled:
         )
         reprec.assertoutcome(skipped=1, failed=1, passed=0)
 
-    def test_unicode_doctest(self, testdir) -> None:
+    def test_unicode_doctest(self, testdir: pytest.Testdir) -> None:
         """
         Test case for issue 2434: DecodeError on Python 2 when xdoctest contains non-ascii
         characters.
@@ -2014,7 +2014,7 @@ class Disabled:
             ]
         )
 
-    def test_reportinfo(self, testdir) -> None:
+    def test_reportinfo(self, testdir: pytest.Testdir) -> None:
         """
         Test case to make sure that XDoctestItem.reportinfo() returns lineno.
         """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1389,7 +1389,7 @@ class TestXDoctestSkips:
             result.stdout.fnmatch_lines(['*no tests ran*'])
 
     @pytest.fixture(params=['text', 'module'])
-    def makedoctest(self, testdir, request):
+    def makedoctest(self, testdir, request) -> None:
         def makeit(xdoctest) -> None:
             mode = request.param
             if mode == 'text':

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -80,8 +80,8 @@ def explicit_testdir() -> None:
     # _pytest.config._preloadplugins()  # to populate pytest.* namespace so help(pytest) works
     import _pytest
 
-    config = _pytest.config._prepareconfig(['-s'], plugins=['pytester'])    # type: ignore
-    session = _pytest.main.Session(config)    # type: ignore
+    config = _pytest.config._prepareconfig(['-s'], plugins=['pytester'])  # type: ignore
+    session = _pytest.main.Session(config)  # type: ignore
 
     _pytest.tmpdir.pytest_configure(config)  # type: ignore
     _pytest.fixtures.pytest_sessionstart(session)  # type: ignore
@@ -90,10 +90,10 @@ def explicit_testdir() -> None:
     def func(testdir) -> None:
         pass
 
-    parent = _pytest.python.Module(    # type: ignore
+    parent = _pytest.python.Module(  # type: ignore
         'parent', config=config, session=session, nodeid='myparent'
     )
-    function = _pytest.python.Function(    # type: ignore
+    function = _pytest.python.Function(  # type: ignore
         'func',
         parent,
         callobj=func,
@@ -1767,7 +1767,9 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['none', 'only_first_failure'])
-    def test_doctest_report_none_or_only_first_failure(self, testdir, format) -> None:
+    def test_doctest_report_none_or_only_first_failure(
+        self, testdir, format
+    ) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_none_or_only_first_failure
         """

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,7 +16,7 @@ from xdoctest.plugin import XDoctestItem, XDoctestModule, XDoctestTextfile
 try:
     from packaging.version import parse as LooseVersion
 except ImportError:
-    from distutils.version import LooseVersion
+    from distutils.version import LooseVersion  # type: ignore
 
 IS_GE_PY306 = sys.version_info[:2] >= (3, 6)
 IS_GE_PY307 = sys.version_info[:2] >= (3, 7)
@@ -37,10 +37,10 @@ OLD_TEXT_ARGS = ['--xdoc-glob=*.txt']
 #         file.write(str(text) + '\n')
 
 
-def explicit_testdir() -> None:
+def explicit_testdir() -> object:
     r"""
     Explicitly constructs a testdir for use in IPython development
-    Note used by any tests.
+    Not used by any tests. We likely should just delete this, or add it to dev. q
 
     # https://xr.gs/2017/07/pytest-dynamic-runtime-fixtures-python3/
     https://stackoverflow.com/questions/45970572/how-to-get-a-pytest-fixture-interactively
@@ -121,10 +121,10 @@ def explicit_testdir() -> None:
         self = function._request
         # argname = 'tmpdir_factory'
         argname = 'testdir'
-        fixturedef = self._arg2fixturedefs.get(argname, None)[0]
-        fixturedef.scope = 'function'
-        self._compute_fixture_value(fixturedef)
-        testdir = fixturedef.cached_result[0]
+        fixturedef = self._arg2fixturedefs.get(argname, None)[0]  # type: ignore
+        fixturedef.scope = 'function'  # type: ignore
+        self._compute_fixture_value(fixturedef)  # type: ignore
+        testdir = fixturedef.cached_result[0]  # type: ignore
 
     # from _pytest.compat import _setup_collect_fakemodule
     # _setup_collect_fakemodule()
@@ -146,8 +146,7 @@ class TestXDoctestActivation:
         Activate `xdoctest` via command-line arguments.
 
         CommandLine:
-            pytest tests/test_plugin.py::TestXDoctestActivation::\
-test_xdoctest_cli_activation
+            pytest tests/test_plugin.py::TestXDoctestActivation::test_xdoctest_cli_activation
         """
         self._check_activation(request, flags, load)
 
@@ -156,8 +155,7 @@ test_xdoctest_cli_activation
         Activate `xdoctest` via config file.
 
         CommandLine:
-            pytest tests/test_plugin.py::TestXDoctestActivation::\
-test_xdoctest_config_activation
+            pytest tests/test_plugin.py::TestXDoctestActivation::test_xdoctest_config_activation
         """
         self._get_tester(request).makeini("""
         [pytest]
@@ -171,8 +169,7 @@ test_xdoctest_config_activation
         command line.
 
         CommandLine:
-            pytest tests/test_plugin.py::TestXDoctestActivation::\
-test_xdoctest_explicit_suppression
+            pytest tests/test_plugin.py::TestXDoctestActivation::test_xdoctest_explicit_suppression
         """
         pdt_namespace_before = self._get_pytest_doctest_module_dict()
         try:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,10 +6,10 @@ Adapted from the original `pytest/tests/test_doctest.py` module at:
 
 import shlex
 import sys
+from pathlib import Path
 
 import _pytest._code
 import pytest
-from pathlib import Path
 
 from xdoctest import utils
 from xdoctest.plugin import XDoctestItem, XDoctestModule, XDoctestTextfile
@@ -142,7 +142,9 @@ class TestXDoctestActivation:
             ('--doctest-modules --xdoctest', True),
         ],
     )
-    def test_xdoctest_cli_activation(self, request, flags: str, load: bool) -> None:
+    def test_xdoctest_cli_activation(
+        self, request, flags: str, load: bool
+    ) -> None:
         """
         Activate `xdoctest` via command-line arguments.
 
@@ -425,7 +427,9 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(skipped=1, failed=0, passed=0)
 
-    def test_doctest_unexpected_exception(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_unexpected_exception(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unexpected_exception
@@ -510,7 +514,9 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_freeform(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_property_lineno_freeform(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -552,7 +558,9 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_property_lineno_google(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -594,7 +602,9 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_property_lineno_google_v2(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_property_lineno_google_v2(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         REPLACES: test_doctest_linedata_missing
         REASON: Static parsing means we do know this line number.
@@ -638,7 +648,9 @@ class TestXDoctest:
             ]
         )
 
-    def test_docstring_show_entire_doctest(self, testdir: pytest.Testdir) -> None:
+    def test_docstring_show_entire_doctest(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """Test that we show the entire doctest when there is a failure
 
         REPLACES: test_docstring_context_around_error
@@ -698,7 +710,9 @@ class TestXDoctest:
         assert 'Example:' not in result.stdout.str()
         assert 'text-line-after' not in result.stdout.str()
 
-    def test_doctest_unex_importerror_only_txt(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_unex_importerror_only_txt(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctest_unex_importerror_only_txt
@@ -719,7 +733,9 @@ class TestXDoctest:
             ]
         )
 
-    def test_doctest_unex_importerror_with_module(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_unex_importerror_with_module(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CHANGES:
             No longer fails during collection because we're doing
@@ -758,7 +774,9 @@ class TestXDoctest:
         sys.path.pop()
 
     @pytest.mark.skip('pytest 3.7.0 broke this. Not sure why')
-    def test_doctestmodule_external_and_issue116(self, testdir: pytest.Testdir) -> None:
+    def test_doctestmodule_external_and_issue116(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_external_and_issue116
@@ -856,7 +874,9 @@ class TestXDoctest:
         )
         reprec.assertoutcome(passed=1)
 
-    def test_txtfile_with_usefixtures_in_ini(self, testdir: pytest.Testdir) -> None:
+    def test_txtfile_with_usefixtures_in_ini(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_txtfile_with_usefixtures_in_ini
@@ -1175,7 +1195,9 @@ class TestXDoctestModuleLevel:
         # print(reprec.listoutcomes())
         reprec.assertoutcome(failed=1)
 
-    def test_collect_module_single_modulelevel_doctest(self, testdir: pytest.Testdir) -> None:
+    def test_collect_module_single_modulelevel_doctest(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_single_modulelevel_doctest
@@ -1194,7 +1216,9 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0], XDoctestItem)
             assert isinstance(items[0].parent, XDoctestModule)
 
-    def test_collect_module_two_doctest_one_modulelevel(self, testdir: pytest.Testdir) -> None:
+    def test_collect_module_two_doctest_one_modulelevel(
+        self, testdir: pytest.Testdir
+    ) -> None:
         path = testdir.makepyfile(
             whatever="""
             '>>> x = None'
@@ -1210,7 +1234,9 @@ class TestXDoctestModuleLevel:
             assert isinstance(items[0].parent, XDoctestModule)
             assert items[0].parent is items[1].parent
 
-    def test_collect_module_two_doctest_no_modulelevel(self, testdir: pytest.Testdir) -> None:
+    def test_collect_module_two_doctest_no_modulelevel(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestModuleLevel::test_collect_module_two_doctest_no_modulelevel
@@ -1452,7 +1478,9 @@ class TestXDoctestSkips:
         # is the case here.
         reprec.assertoutcome(passed=0, skipped=1)
 
-    def test_all_skipped_global(self, testdir: pytest.Testdir, makedoctest) -> None:
+    def test_all_skipped_global(
+        self, testdir: pytest.Testdir, makedoctest
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctestSkips::test_all_skipped_global
@@ -1479,7 +1507,9 @@ class TestXDoctestSkips:
 class TestXDoctestAutoUseFixtures:
     SCOPES = ['module', 'session', 'class', 'function']
 
-    def test_doctest_module_session_fixture(self, testdir: pytest.Testdir) -> None:
+    def test_doctest_module_session_fixture(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         Test that session fixtures are initialized for xdoctest modules (#768)
 
@@ -1593,7 +1623,9 @@ class TestXDoctestAutoUseFixtures:
         result.stdout.fnmatch_lines(['* 1 passed*'])
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_auto_use_request_attributes(self, testdir: pytest.Testdir, scope: str) -> None:
+    def test_auto_use_request_attributes(
+        self, testdir: pytest.Testdir, scope: str
+    ) -> None:
         """Check that all attributes of a request in an autouse fixture
         behave as expected when requested for a xdoctest item.
         """
@@ -1639,7 +1671,9 @@ class TestXDoctestNamespaceFixture:
     SCOPES = ['module', 'session', 'class', 'function']
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_doctestfile(self, testdir: pytest.Testdir, scope: str) -> None:
+    def test_namespace_doctestfile(
+        self, testdir: pytest.Testdir, scope: str
+    ) -> None:
         """
         Check that inserting something into the namespace works in a
         simple text file xdoctest
@@ -1664,7 +1698,9 @@ class TestXDoctestNamespaceFixture:
         reprec.assertoutcome(passed=1)
 
     @pytest.mark.parametrize('scope', SCOPES)
-    def test_namespace_pyfile(self, testdir: pytest.Testdir, scope: str) -> None:
+    def test_namespace_pyfile(
+        self, testdir: pytest.Testdir, scope: str
+    ) -> None:
         """
         Check that inserting something into the namespace works in a
         simple Python file docstring xdoctest
@@ -1714,7 +1750,9 @@ class TestXDoctestReportingOption:
         )
 
     @pytest.mark.parametrize('format', ['udiff', 'UDIFF', 'uDiFf'])
-    def test_doctest_report_udiff(self, testdir: pytest.Testdir, format: str) -> None:
+    def test_doctest_report_udiff(
+        self, testdir: pytest.Testdir, format: str
+    ) -> None:
         """
         pytest tests/test_plugin.py::TestXDoctestReportingOption::test_doctest_report_udiff
         """
@@ -1800,7 +1838,9 @@ class TestXDoctestReportingOption:
 
 
 class Disabled:
-    def test_docstring_context_around_error(self, testdir: pytest.Testdir) -> None:
+    def test_docstring_context_around_error(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """Test that we show some context before the actual line of a failing
         xdoctest.
 
@@ -1913,7 +1953,9 @@ class Disabled:
         reprec = testdir.inline_run(p, '--xdoctest-modules')
         reprec.assertoutcome(passed=3)
 
-    def test_doctestmodule_two_tests_one_fail(self, testdir: pytest.Testdir) -> None:
+    def test_doctestmodule_two_tests_one_fail(
+        self, testdir: pytest.Testdir
+    ) -> None:
         """
         CommandLine:
             pytest tests/test_plugin.py::TestXDoctest::test_doctestmodule_two_tests_one_fail
@@ -1970,7 +2012,9 @@ class Disabled:
         )
         reprec.assertoutcome(failed=1, passed=0)
 
-    def test_ignore_import_errors_on_doctest(self, testdir: pytest.Testdir) -> None:
+    def test_ignore_import_errors_on_doctest(
+        self, testdir: pytest.Testdir
+    ) -> None:
         p = testdir.makepyfile("""
             import asdf
 

--- a/tests/test_preimport.py
+++ b/tests/test_preimport.py
@@ -3,7 +3,7 @@ from os.path import join
 from xdoctest import utils
 
 
-def test_preimport_skiped_on_disabled_module():
+def test_preimport_skiped_on_disabled_module() -> None:
     """
     If our module has no enabled tests, pre-import should never run.
     """
@@ -28,18 +28,20 @@ def test_preimport_skiped_on_disabled_module():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_bad_preimport.py')
+        modpath = join(str(dpath), 'test_bad_preimport.py')
         with open(modpath, 'w') as file:
             file.write(source)
         os.environ['XDOCTEST_TEST_DOITANYWAY'] = ''
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'all', argv=[''])
+        assert cap.text is not None
         assert 'Failed to import modname' not in cap.text
         assert '1 skipped' in cap.text
 
         os.environ['XDOCTEST_TEST_DOITANYWAY'] = '1'
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'all', argv=[])
+        assert cap.text is not None
         assert 'Failed to import modname' in cap.text
 
         del os.environ['XDOCTEST_TEST_DOITANYWAY']

--- a/tests/test_pytest_cli.py
+++ b/tests/test_pytest_cli.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from typing import Any
 

--- a/tests/test_pytest_cli.py
+++ b/tests/test_pytest_cli.py
@@ -26,7 +26,7 @@ def cmd(command):
     return info
 
 
-def test_simple_pytest_cli():
+def test_simple_pytest_cli() -> None:
     module_text = utils.codeblock(
         '''
         def module_func1():
@@ -52,7 +52,7 @@ def test_simple_pytest_cli():
     assert info['ret'] == 0
 
 
-def test_simple_pytest_import_error_cli():
+def test_simple_pytest_import_error_cli() -> None:
     """
     This test case triggers an excessively long callback in xdoctest <
     dev/0.15.7
@@ -133,7 +133,7 @@ def test_simple_pytest_import_error_cli():
     assert info['ret'] != 0
 
 
-def test_simple_pytest_syntax_error_cli():
+def test_simple_pytest_syntax_error_cli() -> None:
     """ """
     module_text = utils.codeblock(
         '''
@@ -158,7 +158,7 @@ def test_simple_pytest_syntax_error_cli():
     assert info['ret'] != 0
 
 
-def test_simple_pytest_import_error_no_xdoctest():
+def test_simple_pytest_import_error_no_xdoctest() -> None:
     """ """
     module_text = utils.codeblock(
         """
@@ -178,7 +178,7 @@ def test_simple_pytest_import_error_no_xdoctest():
     assert info['ret'] != 0
 
 
-def test_simple_pytest_syntax_error_no_xdoctest():
+def test_simple_pytest_syntax_error_no_xdoctest() -> None:
     """ """
     module_text = utils.codeblock(
         """
@@ -198,7 +198,7 @@ def test_simple_pytest_syntax_error_no_xdoctest():
     assert info['ret'] != 0
 
 
-def test_version_and_cli_info():
+def test_version_and_cli_info() -> None:
     """ """
     import xdoctest
 
@@ -209,7 +209,7 @@ def test_version_and_cli_info():
     assert xdoctest.__version__ in info['out']
 
 
-def test_simple_xdoctest_cli():
+def test_simple_xdoctest_cli() -> None:
     module_text = utils.codeblock(
         '''
         def module_func1():
@@ -235,7 +235,7 @@ def test_simple_xdoctest_cli():
     assert info['out'].strip() == ''
 
 
-def test_simple_xdoctest_cli_errors():
+def test_simple_xdoctest_cli_errors() -> None:
     module_text = utils.codeblock(
         '''
         def module_func1():

--- a/tests/test_pytest_cli.py
+++ b/tests/test_pytest_cli.py
@@ -4,7 +4,7 @@ from xdoctest import utils
 from xdoctest.utils import util_misc
 
 
-def cmd(command):
+def cmd(command: str) -> dict[str, object]:
     # simplified version of ub.cmd no fancy tee behavior
     import subprocess
 

--- a/tests/test_pytest_cli.py
+++ b/tests/test_pytest_cli.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
 import sys
+from typing import Any
 
 from xdoctest import utils
 from xdoctest.utils import util_misc
 
 
-def cmd(command: str) -> dict[str, object]:
+def cmd(command: str) -> dict[str, Any]:
     # simplified version of ub.cmd no fancy tee behavior
     import subprocess
 
@@ -17,7 +19,7 @@ def cmd(command: str) -> dict[str, object]:
     )
     out, err = proc.communicate()
     ret = proc.wait()
-    info = {
+    info: dict[str, Any] = {
         'proc': proc,
         'out': out,
         'err': err,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,7 +3,7 @@ from os.path import join
 from xdoctest import utils
 
 
-def test_zero_args():
+def test_zero_args() -> None:
     """
     python tests/test_runner.py test_zero_args
     """
@@ -51,7 +51,7 @@ def test_zero_args():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_zero_args.py')
+        modpath = join(str(dpath), 'test_zero_args.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
@@ -65,7 +65,7 @@ def test_zero_args():
         )
 
 
-def test_list():
+def test_list() -> None:
     from xdoctest import runner
 
     source = utils.codeblock(
@@ -95,14 +95,14 @@ def test_list():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_list.py')
+        modpath = join(str(dpath), 'test_list.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
 
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'list', argv=[''])
-
+        assert cap.text is not None
         assert 'real_test1' in cap.text
         assert 'real_test2' in cap.text
         assert 'fake_test1' not in cap.text
@@ -111,14 +111,14 @@ def test_list():
         # test command=None
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, None, argv=[''])
-
+        assert cap.text is not None
         assert 'real_test1' in cap.text
         assert 'real_test2' in cap.text
         assert 'fake_test1' not in cap.text
         assert 'fake_test2' not in cap.text
 
 
-def test_example_run():
+def test_example_run() -> None:
     from xdoctest import runner
 
     source = utils.codeblock(
@@ -133,18 +133,18 @@ def test_example_run():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_example_run.py')
+        modpath = join(str(dpath), 'test_example_run.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
 
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'foo', argv=[''])
-
+    assert cap.text is not None
     assert 'i wanna see this' in cap.text
 
 
-def test_durations():
+def test_durations() -> None:
     from xdoctest import runner
 
     source = utils.codeblock(
@@ -164,18 +164,20 @@ def test_durations():
     )
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_durations.py')
+        modpath = join(str(dpath), 'test_durations.py')
         with open(modpath, 'w') as file:
             file.write(source)
         with utils.CaptureStdout() as cap1:
             runner.doctest_module(modpath, 'all', argv=[''], durations=10)
         with utils.CaptureStdout() as cap2:
             runner.doctest_module(modpath, 'all', argv=[''], durations=1)
+    assert cap1.text is not None
+    assert cap2.text is not None
     assert cap1.text.count('time: ') == 2, '2 tests should have 2 durations'
     assert cap2.text.count('time: ') == 1, 'should only have gotten 1 durration'
 
 
-def test_dump():
+def test_dump() -> None:
     from xdoctest import runner
 
     source = utils.codeblock(
@@ -199,15 +201,16 @@ def test_dump():
     )
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_durations.py')
+        modpath = join(str(dpath), 'test_durations.py')
         with open(modpath, 'w') as file:
             file.write(source)
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'dump', argv=[''])
+    assert cap.text is not None
     print(cap.text)
 
 
-def test_all_disabled():
+def test_all_disabled() -> None:
     """
     pytest tests/test_runner.py::test_all_disabled -s -vv
     python tests/test_runner.py test_all_disabled
@@ -233,7 +236,7 @@ def test_all_disabled():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_all_disabled.py')
+        modpath = join(str(dpath), 'test_all_disabled.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
@@ -241,6 +244,7 @@ def test_all_disabled():
         # disabled tests dont run in "all" mode
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'all', argv=[''])
+        assert cap.text is not None
         assert 'all will print this' in cap.text
         # print('    ' + cap.text.replace('\n', '\n    '))
         assert 'all will not print this' not in cap.text
@@ -248,11 +252,12 @@ def test_all_disabled():
         # Running an disabled example explicitly should work
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'foo', argv=[''])
+        assert cap.text is not None
         # print('    ' + cap.text.replace('\n', '\n    '))
         assert 'all will not print this' in cap.text
 
 
-def test_runner_failures():
+def test_runner_failures() -> None:
     """
     python tests/test_runner.py  test_runner_failures
     pytest tests/test_runner.py::test_runner_failures -s
@@ -298,7 +303,7 @@ def test_runner_failures():
     temp.ensure()
     # with utils.TempDir() as temp:
     dpath = temp.dpath
-    modpath = join(dpath, 'test_runner_failures.py')
+    modpath = join(str(dpath), 'test_runner_failures.py')
 
     with open(modpath, 'w') as file:
         file.write(source)
@@ -311,6 +316,7 @@ def test_runner_failures():
             pass
 
     print('\nNOTE: the following output is part of a test')
+    assert cap.text is not None
     print(utils.indent(cap.text, '... '))
     print('NOTE: above output is part of a test')
 
@@ -320,7 +326,7 @@ def test_runner_failures():
     assert '3 passed' in cap.text
 
 
-def test_run_zero_arg():
+def test_run_zero_arg() -> None:
     """
     pytest tests/test_runner.py::test_run_zero_arg -s
     """
@@ -335,7 +341,7 @@ def test_run_zero_arg():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_run_zero_arg.py')
+        modpath = join(str(dpath), 'test_run_zero_arg.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
@@ -346,6 +352,7 @@ def test_run_zero_arg():
                 runner.doctest_module(modpath, 'all', argv=[''], verbose=3)
             except Exception:
                 pass
+        assert cap.text is not None
         assert 'running zero arg' not in cap.text
 
         with utils.CaptureStdout() as cap:
@@ -355,11 +362,12 @@ def test_run_zero_arg():
                 )
             except Exception:
                 pass
+        assert cap.text is not None
         # print(cap.text)
         assert 'running zero arg' in cap.text
 
 
-def test_parse_cmdline():
+def test_parse_cmdline() -> None:
     """
     pytest tests/test_runner.py::test_parse_cmdline -s
     """
@@ -388,7 +396,7 @@ def test_parse_cmdline():
     )
 
 
-def test_runner_config():
+def test_runner_config() -> None:
     """
     pytest tests/test_runner.py::test_runner_config -s
     """
@@ -410,18 +418,18 @@ def test_runner_config():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_example_run.py')
+        modpath = join(str(dpath), 'test_example_run.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
 
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'foo', argv=[''], config=config)
-
+    assert cap.text is not None
     assert 'SKIPPED' in cap.text
 
 
-def test_global_exec():
+def test_global_exec() -> None:
     """
     pytest tests/test_runner.py::test_global_exec -s
     """
@@ -443,18 +451,18 @@ def test_global_exec():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_example_run.py')
+        modpath = join(str(dpath), 'test_example_run.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
 
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'foo', argv=[''], config=config)
-
+    assert cap.text is not None
     assert '1 passed' in cap.text
 
 
-def test_hack_the_sys_argv():
+def test_hack_the_sys_argv() -> None:
     """
     Tests hacky solution to issue #76
 
@@ -486,14 +494,14 @@ def test_hack_the_sys_argv():
 
     with utils.TempDir() as temp:
         dpath = temp.dpath
-        modpath = join(dpath, 'test_example_run.py')
+        modpath = join(str(dpath), 'test_example_run.py')
 
         with open(modpath, 'w') as file:
             file.write(source)
 
         with utils.CaptureStdout() as cap:
             runner.doctest_module(modpath, 'foo', argv=[''], config=config)
-
+    assert cap.text is not None
     if 0 and NEEDS_FIX:
         # Fix the global state
         sys.argv.remove('--hackedflag')

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -4,7 +4,7 @@ from xdoctest import static_analysis as static
 from xdoctest import utils
 
 
-def test_module_docstr():
+def test_module_docstr() -> None:
     source = utils.codeblock(
         '''
         # comment
@@ -21,7 +21,7 @@ def test_module_docstr():
     assert '__doc__' in self.calldefs
 
 
-def test_lineno():
+def test_lineno() -> None:
     source = utils.codeblock(
         '''
         def foo():
@@ -70,7 +70,7 @@ def test_lineno():
         assert docsrc_lines[-1].strip().endswith('"""')
 
 
-def test_mod_lineno2():
+def test_mod_lineno2() -> None:
     source = utils.codeblock(
         '''
         class Fun:  #1
@@ -135,7 +135,7 @@ def test_mod_lineno2():
     assert calldefs['decor4'].doclineno_end == 38
 
 
-def test_async_function_docstr_collection():
+def test_async_function_docstr_collection() -> None:
     source = utils.codeblock(
         '''
         async def b():
@@ -153,7 +153,7 @@ def test_async_function_docstr_collection():
     assert self.calldefs['b'].doclineno_end == 5
 
 
-def test_parse_decorated_async_function_lineno():
+def test_parse_decorated_async_function_lineno() -> None:
     source = utils.codeblock(
         '''
         def deco(func):
@@ -187,7 +187,7 @@ def test_parse_decorated_async_function_lineno():
     assert '>>> 1 + 1' in calldef.docstr
 
 
-def test_parse_multi_decorated_async_function_lineno():
+def test_parse_multi_decorated_async_function_lineno() -> None:
     source = utils.codeblock(
         '''
         def deco1(func):
@@ -465,7 +465,7 @@ def test_parse_multi_decorated_async_function_lineno():
         },
     ],
 )
-def test_parse_decorated_function_lineno_cases(case):
+def test_parse_decorated_function_lineno_cases(case) -> None:
     source = utils.codeblock(case['source'])
 
     calldefs = static.parse_static_calldefs(

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -58,7 +58,9 @@ def test_lineno() -> None:
     sourcelines = source.split('\n')
 
     for k, calldef in calldefs.items():
-        line = sourcelines[calldef.lineno - 1]
+        lineno = calldef.lineno
+        assert isinstance(lineno, int)
+        line = sourcelines[lineno - 1]
         callname = calldef.callname
         # Ensure linenumbers correspond with start of func/class def
         assert callname.split('.')[-1] in line

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -64,6 +64,8 @@ def test_lineno() -> None:
         callname = calldef.callname
         # Ensure linenumbers correspond with start of func/class def
         assert callname.split('.')[-1] in line
+        assert calldef.doclineno is not None
+        assert calldef.doclineno_end is not None
         docsrc_lines = sourcelines[
             calldef.doclineno - 1 : calldef.doclineno_end
         ]
@@ -183,9 +185,11 @@ def test_parse_decorated_async_function_lineno() -> None:
 
     # Should point to the `async def foo():` line, not the decorator line.
     source_lines = source.splitlines()
+    assert calldef.lineno is not None
     assert source_lines[calldef.lineno - 1].strip() == 'async def foo():'
 
     # And it should still extract the docstring normally.
+    assert calldef.docstr is not None
     assert '>>> 1 + 1' in calldef.docstr
 
 
@@ -217,7 +221,9 @@ def test_parse_multi_decorated_async_function_lineno() -> None:
     calldef = calldefs['foo']
 
     source_lines = source.splitlines()
+    assert calldef.lineno is not None
     assert source_lines[calldef.lineno - 1].strip() == 'async def foo():'
+    assert calldef.docstr is not None
     assert '>>> 1 + 1' in calldef.docstr
 
 
@@ -484,6 +490,7 @@ def test_parse_decorated_function_lineno_cases(case) -> None:
     calldef = calldefs[case['callname']]
     source_lines = source.splitlines()
 
+    assert calldef.lineno is not None
     got_line = source_lines[calldef.lineno - 1].strip()
     assert got_line == case['expect_line'], (
         'Wrong lineno for case={!r}. Expected line={!r}, got line={!r}, '
@@ -492,6 +499,7 @@ def test_parse_decorated_function_lineno_cases(case) -> None:
         )
     )
 
+    assert calldef.docstr is not None
     assert '>>> 1 + 1' in calldef.docstr or '>>> "bar"' in calldef.docstr
 
 

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,6 +1,7 @@
 """
 Need to enhance the tracebacks to spit out something more useful
 """
+from __future__ import annotations
 
 from xdoctest import utils
 from xdoctest.utils.util_misc import _run_case

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,6 +1,7 @@
 """
 Need to enhance the tracebacks to spit out something more useful
 """
+
 from __future__ import annotations
 
 from xdoctest import utils

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -6,7 +6,7 @@ from xdoctest import utils
 from xdoctest.utils.util_misc import _run_case
 
 
-def test_fail_call_onefunc():
+def test_fail_call_onefunc() -> None:
     import warnings
 
     with warnings.catch_warnings():
@@ -25,11 +25,12 @@ def test_fail_call_onefunc():
             '''
             )
         )
+        assert text is not None
         assert '>>> func(a)' in text
         assert 'rel: 2, abs: 5' in text
 
 
-def test_fail_call_twofunc():
+def test_fail_call_twofunc() -> None:
     """
     python ~/code/xdoctest/tests/test_traceback.py test_fail_call_twofunc
 
@@ -59,12 +60,12 @@ def test_fail_call_twofunc():
             '''
             )
         )
-        assert text
+        assert text is not None
         assert '>>> func(a)' in text
         assert 'rel: 2, abs: 5,' in text
 
 
-def test_fail_inside_twofunc():
+def test_fail_inside_twofunc() -> None:
     """
     python ~/code/xdoctest/tests/test_traceback.py test_fail_inside_twofunc
 
@@ -97,12 +98,12 @@ def test_fail_inside_twofunc():
             '''
             )
         )
-        assert text
+        assert text is not None
         assert '>>> a = []()' in text
         assert 'rel: 5, abs: 8' in text
 
 
-def test_fail_inside_onefunc():
+def test_fail_inside_onefunc() -> None:
     """
     python ~/code/xdoctest/tests/test_traceback.py test_fail_inside_onefunc
 
@@ -125,12 +126,12 @@ def test_fail_inside_onefunc():
         '''
         )
     )
-    assert text
+    assert text is not None
     assert '>>> a = []()' in text
     assert 'rel: 6, abs: 9,' in text
 
 
-def test_failure_linenos():
+def test_failure_linenos() -> None:
     """
     Example:
         python ~/code/xdoctest/tests/test_linenos.py test_failure_linenos
@@ -167,9 +168,9 @@ def test_failure_linenos():
         )
     )
 
+    assert text is not None
     assert 'line 15' in text
     assert 'line 6' in text
-    assert text
 
 
 # There are three different types of traceback failure
@@ -191,7 +192,7 @@ SeeAlso:
 """
 
 
-def test_lineno_failcase_gotwant():
+def test_lineno_failcase_gotwant() -> None:
     """
     python ~/code/xdoctest/tests/test_linenos.py test_lineno_failcase_gotwant
 
@@ -210,12 +211,12 @@ def test_lineno_failcase_gotwant():
         '''
         )
     )
-    assert text
+    assert text is not None
     assert 'line 3' in text
     assert 'line 6' in text
 
 
-def test_lineno_failcase_called_code():
+def test_lineno_failcase_called_code() -> None:
     """
     python ~/code/xdoctest/tests/test_linenos.py test_lineno_failcase_called_code
     python ~/code/xdoctest/tests/test_linenos.py
@@ -246,11 +247,11 @@ def test_lineno_failcase_called_code():
         '''
         )
     )
+    assert text is not None
     assert 'rel: 6, abs: 9,' in text
-    assert text
 
 
-def test_lineno_failcase_doctest_code():
+def test_lineno_failcase_doctest_code() -> None:
     """
     python ~/code/xdoctest/tests/test_linenos.py test_lineno_failcase_doctest_code
 
@@ -279,8 +280,8 @@ def test_lineno_failcase_doctest_code():
         '''
         )
     )
+    assert text is not None
     assert 'rel: 5, abs: 11,' in text
-    assert text
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a development branch where I'm continuing the typing / formatting work.

This also includes a bug fix for an issues that apparently has existed for along time when you have a multi-part doctest that has some nested error:

e.g. 

```
        >>> def foo():
        >>>     raise ValueError('boom')
        >>> print('ready')
        ready
       >>> foo()
```