### PR TITLE
Add options to better match stdlib doctest behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Version 1.3.3 - Unreleased
 
+### Added
+* Added `deferred_output_matching` and `optional_want` config knobs, plus CLI
+  flags, to opt into stdlib/doctest-like output semantics without changing the
+  default xdoctest behavior.
+
 ### Fixed
 * Fixed issue #181 where comment indentation could cause parsing issues.
 * Fix traceback rewriting for exceptions raised in earlier doctest parts

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -624,8 +624,9 @@ class GotWantException(AssertionError):
                     got = utils.color_text(got, 'red')
                     want = utils.color_text(want, 'red')
                 text = 'Expected:\n{}\nGot nothing\n'.format(utils.indent(want))
-            elif got:  # nocover
-                raise AssertionError('impossible state')
+            elif got:
+                if colored:
+                    got = utils.color_text(got, 'red')
                 text = 'Expected nothing\nGot:\n{}'.format(utils.indent(got))
             else:  # nocover
                 raise AssertionError('impossible state')

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -58,7 +58,9 @@ class DoctestConfig(dict):
                 'reportchoice': 'udiff',
                 'default_runtime_state': {},
                 'offset_linenos': False,
+                'deferred_output_matching': True,
                 'global_exec': None,
+                'optional_want': True,
                 'supress_import_errors': False,
                 'on_error': 'raise',
                 'partnos': False,
@@ -82,10 +84,12 @@ class DoctestConfig(dict):
                 default_runtime_state[directive.name] = directive.positive
         _examp_conf = {
             'default_runtime_state': default_runtime_state,
+            'deferred_output_matching': ns['deferred_output_matching'],
             'offset_linenos': ns['offset_linenos'],
             'colored': ns['colored'],
             'reportchoice': ns['reportchoice'],
             'global_exec': ns['global_exec'],
+            'optional_want': ns['optional_want'],
             'supress_import_errors': ns['supress_import_errors'],
             'verbose': ns['verbose'],
         }
@@ -141,6 +145,29 @@ class DoctestConfig(dict):
                 ),
             ),
             (
+                ['--deferred-output-matching'],
+                dict(
+                    dest='deferred_output_matching',
+                    action='store_true',
+                    default=self['deferred_output_matching'],
+                    help=(
+                        'Allow stdout from no-want parts to be matched by a '
+                        'later want-bearing part'
+                    ),
+                ),
+            ),
+            (
+                ['--no-deferred-output-matching'],
+                dict(
+                    dest='deferred_output_matching',
+                    action='store_false',
+                    default=argparse.SUPPRESS,
+                    help=(
+                        'Disable deferred stdout matching between parts'
+                    ),
+                ),
+            ),
+            (
                 ['--report'],
                 dict(
                     dest='reportchoice',
@@ -175,6 +202,24 @@ class DoctestConfig(dict):
                     default=None,
                     dest='global_exec',
                     help='Custom Python code to execute before every test',
+                ),
+            ),
+            (
+                ['--optional-want'],
+                dict(
+                    dest='optional_want',
+                    action='store_true',
+                    default=self['optional_want'],
+                    help='Allow parts to omit local want output',
+                ),
+            ),
+            (
+                ['--no-optional-want'],
+                dict(
+                    dest='optional_want',
+                    action='store_false',
+                    default=argparse.SUPPRESS,
+                    help='Require each output-producing part to have a want',
                 ),
             ),
             # FIXME: this has a spelling error
@@ -230,7 +275,14 @@ class DoctestConfig(dict):
         # TODO: make environment variables as args more general
         import os
 
-        environ_aware = {'report', 'options', 'global-exec', 'verbose'}
+        environ_aware = {
+            'deferred-output-matching',
+            'optional-want',
+            'report',
+            'options',
+            'global-exec',
+            'verbose',
+        }
         for alias, kw in add_argument_kws:
             # Use environment variables for some defaults
             argname = alias[0].lstrip('-')
@@ -1388,10 +1440,31 @@ class DocTest:
         a no-want part, that part's output is discarded and must not contribute
         to any later deferred match.
         """
+        deferred_output_matching = bool(
+            self.config.getvalue('deferred_output_matching')
+        )
+        optional_want = bool(self.config.getvalue('optional_want'))
+
         if part.want is None:
             if runstate['IGNORE_WANT']:
                 self._unmatched_stdout = []
-            else:
+                return
+
+            has_stdout = bool(got_stdout)
+            has_eval = got_eval is not constants.NOT_EVALED
+            if not optional_want and (has_stdout or has_eval):
+                if has_stdout:
+                    assert got_stdout is not None
+                    got = got_stdout
+                else:
+                    got = repr(got_eval)
+                raise checker.GotWantException(
+                    'got output with no local want',
+                    got,
+                    '',
+                )
+
+            if deferred_output_matching and has_stdout:
                 assert got_stdout is not None
                 assert self._unmatched_stdout is not None
                 self._unmatched_stdout.append(got_stdout)
@@ -1484,7 +1557,9 @@ class DocTest:
                 # Same idea here: got/want failures are about the currently
                 # failed part's want block.
                 offset = self.failed_part.line_offset
-                offset += self.failed_part.n_exec_lines + 1
+                offset += self.failed_part.n_exec_lines
+                if self.failed_part.want is not None:
+                    offset += 1
 
             else:
                 # For ordinary execution exceptions, the relevant line may be

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1430,15 +1430,15 @@ class DocTest:
         runstate: directive.RuntimeState,
     ) -> None:
         """
-        Apply xdoctest's current output contract for one executed part.
+        Apply the configured output contract for one executed part.
 
-        Parts with a local want are checked immediately unless IGNORE_WANT is
-        active. After any want-bearing part, deferred stdout is cleared.
-
-        Parts without a local want normally defer stdout so a later part may
-        consume it via trailing matching. However, if IGNORE_WANT is active on
-        a no-want part, that part's output is discarded and must not contribute
-        to any later deferred match.
+        With the default configuration, parts without a local want may defer
+        stdout for later trailing matching, while parts with a local want are
+        checked immediately. The `deferred_output_matching` knob disables the
+        deferred-trailing behavior, and `optional_want` requires output
+        producing parts to have a local want unless `IGNORE_WANT` is active.
+        Any part with `IGNORE_WANT` active is treated as a boundary and does
+        not contribute output to later matching.
         """
         deferred_output_matching = bool(
             self.config.getvalue('deferred_output_matching')
@@ -1457,7 +1457,15 @@ class DocTest:
                     assert got_stdout is not None
                     got = got_stdout
                 else:
-                    got = repr(got_eval)
+                    try:
+                        got = repr(got_eval)
+                    except Exception as ex:
+                        raise checker.ExtractGotReprException(
+                            'Error calling repr for {}. Caused by: {!r}'.format(
+                                type(got_eval), ex
+                            ),
+                            ex,
+                        )
                 raise checker.GotWantException(
                     'got output with no local want',
                     got,

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import typing
 
 from xdoctest import checker, constants, doctest_example, exceptions, utils
@@ -249,6 +250,117 @@ def test_run_trailing_stdout_from_no_want_part() -> None:
     assert result['passed']
     assert self.logged_stdout is not None
     assert list(self.logged_stdout.values()) == ['prefix\n', 'suffix\n']
+
+
+def test_doctestconfig_cli_flags() -> None:
+    config = doctest_example.DoctestConfig()
+
+    parser = argparse.ArgumentParser()
+    config._update_argparse_cli(parser.add_argument)
+    ns = parser.parse_args(
+        ['--no-optional-want', '--deferred-output-matching']
+    )
+    assert ns.optional_want is False
+    assert ns.deferred_output_matching is True
+
+    prefixed = argparse.ArgumentParser()
+    config._update_argparse_cli(prefixed.add_argument, prefix=['xdoctest'])
+    ns2 = prefixed.parse_args(
+        ['--xdoctest-no-optional-want', '--xdoctest-no-deferred-output-matching']
+    )
+    assert ns2.xdoctest_optional_want is False
+    assert ns2.xdoctest_deferred_output_matching is False
+
+
+def test_optional_want_false_fails_on_stdout() -> None:
+    docsrc = utils.codeblock(
+        """
+        >>> print('foo')
+        """
+    )
+    self = doctest_example.DocTest(docsrc=docsrc)
+    self.config['optional_want'] = False
+
+    result = self.run(verbose=0, on_error='return')
+
+    assert result['failed']
+    fail_text = '\n'.join(self.repr_failure())
+    assert 'Expected nothing' in fail_text
+    assert 'foo' in fail_text
+
+
+def test_optional_want_false_fails_on_eval_output() -> None:
+    docsrc = utils.codeblock(
+        """
+        >>> 1 + 1
+        """
+    )
+    self = doctest_example.DocTest(docsrc=docsrc)
+    self._parse()
+    assert self._parts is not None
+    self._parts[0].compile_mode = 'eval'
+    self.config['optional_want'] = False
+
+    result = self.run(verbose=0, on_error='return')
+
+    assert result['failed']
+    fail_text = '\n'.join(self.repr_failure())
+    assert 'Expected nothing' in fail_text
+    assert '2' in fail_text
+
+
+def test_optional_want_false_ignored_no_want_part_passes() -> None:
+    docsrc = utils.codeblock(
+        """
+        >>> print('foo')  # xdoctest: +IGNORE_WANT
+        """
+    )
+    self = doctest_example.DocTest(docsrc=docsrc)
+    self.config['optional_want'] = False
+
+    result = self.run(verbose=0, on_error='return')
+
+    assert result['passed']
+
+
+def test_deferred_output_matching_false_disables_trailing_match() -> None:
+    docsrc = utils.codeblock(
+        """
+        >>> print('foo')
+        >>> print('bar')
+        foo
+        bar
+        """
+    )
+
+    default = doctest_example.DocTest(docsrc=docsrc)
+    default_result = default.run(verbose=0)
+    assert default_result['passed']
+
+    self = doctest_example.DocTest(docsrc=docsrc)
+    self.config['deferred_output_matching'] = False
+    result = self.run(verbose=0, on_error='return')
+    assert result['failed']
+    fail_text = '\n'.join(self.repr_failure())
+    assert 'foo' in fail_text
+    assert 'bar' in fail_text
+
+
+def test_output_toggle_knobs_are_orthogonal() -> None:
+    docsrc = utils.codeblock(
+        """
+        >>> print('foo')
+        """
+    )
+    self = doctest_example.DocTest(docsrc=docsrc)
+    self.config['deferred_output_matching'] = False
+    self.config['optional_want'] = False
+
+    result = self.run(verbose=0, on_error='return')
+
+    assert result['failed']
+    fail_text = '\n'.join(self.repr_failure())
+    assert 'Expected nothing' in fail_text
 
 
 def test_ignore_want_clears_unmatched_stdout() -> None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pytest
 
-from xdoctest import core, exceptions, runner, utils
+from xdoctest import core, doctest_example, exceptions, runner, utils
 from xdoctest.utils.util_misc import _run_case
 
 
@@ -205,6 +205,34 @@ def test_extract_got_exception() -> None:
     text = _run_case(source, style='google')
     assert text is not None
     assert 'ExtractGotReprException' in text
+
+
+def test_optional_want_false_extracts_bad_repr() -> None:
+    """
+    A no-want eval output should still report bad reprs through the existing
+    got-repr failure machinery when optional_want is disabled.
+    """
+    class MyObj:
+        def __repr__(self) -> str:
+            raise Exception('this repr fails')
+
+    source = utils.codeblock(
+        '''
+        >>> obj
+        '''
+    )
+    self = doctest_example.DocTest(docsrc=source)
+    self._parse()
+    assert self._parts is not None
+    self._parts[0].compile_mode = 'eval'
+    self.global_namespace['obj'] = MyObj()
+    self.config['optional_want'] = False
+    result = self.run(on_error='return', verbose=0)
+    assert result['failed']
+
+    text = '\n'.join(self.repr_failure())
+    assert 'ExtractGotReprException' in text
+    assert 'this repr fails' in text
 
 
 def test_traceback_rewrite_handles_inner_frame_from_prior_part():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -427,6 +427,26 @@ class TestXDoctest:
         reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(skipped=1, failed=0, passed=0)
 
+    def test_xdoctest_optional_want_addopts(self, testdir: pytest.Testdir) -> None:
+        """Test prefixed config knobs in pytest addopts.
+
+        CommandLine:
+            pytest tests/test_plugin.py::TestXDoctest::test_xdoctest_optional_want_addopts
+        """
+        testdir.makeini("""
+            [pytest]
+            addopts= --xdoctest-no-optional-want
+        """)
+        p = testdir.makepyfile('''
+            def say_foo():
+                """
+                >>> print('foo')
+                """
+                return None
+        ''')
+        reprec = testdir.inline_run(p, '--xdoctest-modules', *EXTRA_ARGS)
+        reprec.assertoutcome(skipped=0, failed=1, passed=0)
+
     def test_doctest_unexpected_exception(
         self, testdir: pytest.Testdir
     ) -> None:


### PR DESCRIPTION
Adds two options that make xdoctest able to behave in the same way as the stdlib doctest at runtime. 