### PR TITLE
Cache and report module doctest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 ### Changed
+* Cached static module doctest metadata using file identity, and report specific `__doctest_skip__` and `__doctest_requires__` reasons through pytest.
 * Native xdoctest output checks now keep structured runtime state on the fast
   path. Stdlib optionflag conversion occurs only for foreign checkers or sparse
   compatibility mappings. The native checker name is reserved; foreign checker

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import __future__
 
 import ast
+import functools
 from contextlib import AbstractContextManager, nullcontext
 import math
 import os
@@ -412,6 +413,66 @@ def _doctest_requirement_satisfied(requirement_text: str) -> bool:
     return requirement.specifier.contains(installed_version, prereleases=True)
 
 
+@functools.lru_cache(maxsize=256)
+def _read_static_module_doctest_metadata_cached(
+    modpath: str,
+    mtime_ns: int,
+    ctime_ns: int,
+    size: int,
+) -> tuple[Any, Any]:
+    """Read static metadata for one immutable file identity."""
+    # The stat fields participate in the cache key. Parsing only needs the path.
+    del mtime_ns, ctime_ns, size
+    values: list[Any] = []
+    for key in ['__doctest_skip__', '__doctest_requires__']:
+        try:
+            value = static.parse_static_value(key, fpath=modpath)
+        except NameError:
+            value = None
+        except Exception as ex:
+            raise ValueError(
+                'Failed to read {!r} from {!r}: {}'.format(key, modpath, ex)
+            ) from ex
+        values.append(value)
+    return values[0], values[1]
+
+
+def _static_module_doctest_metadata(
+    modpath: str | os.PathLike[str],
+) -> tuple[Any, Any]:
+    r"""
+    Read ``__doctest_skip__`` and ``__doctest_requires__`` statically.
+
+    Results are shared by doctests from the same unchanged module. The file's
+    modification time, change time, and size are part of the cache key, so an
+    edited module is reparsed rather than returning stale metadata.
+
+    Example:
+        >>> import tempfile
+        >>> from pathlib import Path
+        >>> dpath = Path(tempfile.mkdtemp())
+        >>> modpath = dpath / 'demo_metadata.py'
+        >>> _ = modpath.write_text("__doctest_skip__ = ['first']\n")
+        >>> _read_static_module_doctest_metadata_cached.cache_clear()
+        >>> first = _static_module_doctest_metadata(modpath)
+        >>> again = _static_module_doctest_metadata(modpath)
+        >>> again is first
+        True
+        >>> _ = modpath.write_text("__doctest_skip__ = ['second', 'changed']\n")
+        >>> changed = _static_module_doctest_metadata(modpath)
+        >>> changed[0]
+        ['second', 'changed']
+    """
+    path = os.path.realpath(os.fspath(modpath))
+    stat = os.stat(path)
+    return _read_static_module_doctest_metadata_cached(
+        path,
+        stat.st_mtime_ns,
+        stat.st_ctime_ns,
+        stat.st_size,
+    )
+
+
 class DocTest:
     """
     Holds information necessary to execute and verify a doctest
@@ -421,7 +482,7 @@ class DocTest:
         docsrc (str):
             doctest source code
 
-        modpath (str | PathLike | None):
+        modpath (str | PathLike | ModuleType | None):
             module the source was read from
 
         callname (str):
@@ -508,7 +569,8 @@ class DocTest:
     # Attribute annotations derived from docstring
     module: types.ModuleType | None
     modname: str | None
-    fpath: str | os.PathLike | None
+    modpath: str | os.PathLike[str]
+    fpath: str | os.PathLike[str] | None
     docsrc: str | None
     lineno: int | None
     num: int | None
@@ -542,18 +604,18 @@ class DocTest:
     def __init__(
         self,
         docsrc: str,
-        modpath: str | os.PathLike | None = None,
+        modpath: str | os.PathLike[str] | types.ModuleType | None = None,
         callname: str | None = None,
         num: int = 0,
         lineno: int = 1,
-        fpath: str | os.PathLike | None = None,
+        fpath: str | os.PathLike[str] | None = None,
         block_type: str | None = None,
         mode: str = 'pytest',
     ) -> None:
         """
         Args:
             docsrc (str): the text of the doctest
-            modpath (str | PathLike | None):
+            modpath (str | PathLike | ModuleType | None):
             callname (str | None):
             num (int):
             lineno (int):
@@ -567,25 +629,25 @@ class DocTest:
         self.config = DoctestConfig()
 
         self.module = None
-        self.modpath = modpath
-
         self.fpath = fpath
         if modpath is None:
             self.modname = self.UNKNOWN_MODNAME
             self.modpath = self.UNKNOWN_MODPATH
         elif isinstance(modpath, types.ModuleType):
-            self.fpath = modpath
             self.module = modpath
             self.modname = modpath.__name__
-            self.modpath = getattr(
-                self.module, '__file__', self.UNKNOWN_MODPATH
-            )
+            module_fpath = getattr(modpath, '__file__', None)
+            if isinstance(module_fpath, str):
+                self.modpath = module_fpath
+            else:
+                self.modpath = self.UNKNOWN_MODPATH
+            self.fpath = self.modpath
         else:
-            if fpath is not None:
-                if fpath != modpath:
-                    raise AssertionError(
-                        'only specify fpath for non-python files'
-                    )
+            self.modpath = modpath
+            if fpath is not None and fpath != modpath:
+                raise AssertionError(
+                    'only specify fpath for non-python files'
+                )
             self.fpath = modpath
             self.modname = static.modpath_to_modname(modpath)
         if callname is None:
@@ -618,6 +680,7 @@ class DocTest:
         self.logged_stdout = OrderedDict()
         self._unmatched_stdout = []
         self._skipped_parts = []
+        self._metadata_skip_reason: str | None = None
 
         self._runstate = None
 
@@ -1079,50 +1142,42 @@ class DocTest:
 
     def _apply_module_doctest_metadata(
         self, runstate: directive.RuntimeState
-    ) -> None:
+    ) -> str | None:
         """
-        Apply module-level doctestplus metadata to the current example.
+        Apply module-level doctest metadata and return a concrete skip reason.
 
-        This is intentionally evaluated after the :class:`DocTest` already
-        exists and has a callname, so the parser output shape stays unchanged.
+        Loaded modules are authoritative because their metadata may be computed
+        dynamically. Otherwise the source file is read through the stat-aware
+        static metadata cache. This method is called once for each run, while
+        unchanged file parsing is shared across doctests from the same module.
         """
-        skip_spec = None
-        requires_spec = None
+        skip_spec: Any = None
+        requires_spec: Any = None
 
         if self.module is not None:
             skip_spec = getattr(self.module, '__doctest_skip__', None)
             requires_spec = getattr(self.module, '__doctest_requires__', None)
         else:
             modpath = self.modpath
-            if isinstance(modpath, (str, os.PathLike)) and os.path.exists(
-                modpath
-            ):
-                for key in ['__doctest_skip__', '__doctest_requires__']:
-                    try:
-                        value = static.parse_static_value(
-                            key, fpath=os.fspath(modpath)
-                        )
-                    except NameError:
-                        value = None
-                    except Exception as ex:
-                        raise ValueError(
-                            'Failed to read {!r} from {!r}: {}'.format(
-                                key, modpath, ex
-                            )
-                        )
-                    if key == '__doctest_skip__':
-                        skip_spec = value
-                    else:
-                        requires_spec = value
+            if os.path.exists(modpath):
+                skip_spec, requires_spec = _static_module_doctest_metadata(
+                    modpath
+                )
 
         if skip_spec is not None and self._matches_doctest_skip(skip_spec):
             runstate['SKIP'] = True
-            return
+            return 'listed in `__doctest_skip__`'
 
-        if requires_spec is not None and not self._module_requires_satisfied(
-            requires_spec
-        ):
-            runstate['SKIP'] = True
+        if requires_spec is not None:
+            unmet = self._unmet_module_requirement(requires_spec)
+            if unmet is not None:
+                runstate['SKIP'] = True
+                return (
+                    'unmet `__doctest_requires__` requirement: {!r}'.format(
+                        unmet
+                    )
+                )
+        return None
 
     def _matches_doctest_skip(self, skip_spec: Any) -> bool:
         if isinstance(skip_spec, str):
@@ -1147,7 +1202,8 @@ class DocTest:
                 return True
         return False
 
-    def _module_requires_satisfied(self, requires_spec: Any) -> bool:
+    def _unmet_module_requirement(self, requires_spec: Any) -> str | None:
+        """Return the first applicable unmet module requirement, if any."""
         if not isinstance(requires_spec, dict):
             raise ValueError(
                 '__doctest_requires__ must be a dictionary of patterns to requirements'
@@ -1158,20 +1214,33 @@ class DocTest:
                 patterns = [key]
             elif isinstance(key, (list, tuple, set)):
                 patterns = list(key)
+                if isinstance(key, set):
+                    patterns.sort(key=repr)
             else:
                 raise ValueError(
                     '__doctest_requires__ keys must be strings or sequences of strings'
                 )
+
+            for pattern in patterns:
+                if not isinstance(pattern, str):
+                    raise ValueError(
+                        '__doctest_requires__ patterns must be strings, got {!r}'.format(
+                            pattern
+                        )
+                    )
 
             if not any(
                 fnmatch(self.callname, pattern if pattern != '.' else '__doc__')
                 for pattern in patterns
             ):
                 continue
+
             if isinstance(reqs, str):
                 req_list = [reqs]
             elif isinstance(reqs, (list, tuple, set)):
                 req_list = list(reqs)
+                if isinstance(reqs, set):
+                    req_list.sort(key=repr)
             else:
                 raise ValueError(
                     '__doctest_requires__ values must be strings or sequences of strings'
@@ -1183,9 +1252,16 @@ class DocTest:
                         '__doctest_requires__ requirements must be strings'
                     )
                 if not _doctest_requirement_satisfied(req_text):
-                    return False
+                    return req_text
 
-        return True
+        return None
+
+    def _skip_reason(self) -> str:
+        """Return the most specific available reason for a full skip."""
+        return (
+            self._metadata_skip_reason
+            or 'doctest is empty or all parts were skipped'
+        )
 
     def run(
         self, verbose: int | None | bool = None, on_error: str | None = None
@@ -1220,6 +1296,7 @@ class DocTest:
 
         self._skipped_parts = []
         self.exc_info = None
+        self._metadata_skip_reason = None
         self._suppressed_stdout = verbose <= 1
 
         # Reset traceback bookkeeping from any prior run.
@@ -1337,7 +1414,9 @@ class DocTest:
                             summary = self._post_run(verbose)
                             return summary
 
-                    self._apply_module_doctest_metadata(runstate)
+                    self._metadata_skip_reason = (
+                        self._apply_module_doctest_metadata(runstate)
+                    )
 
                     if runstate['SKIP']:
                         if DEBUG:
@@ -1667,7 +1746,7 @@ class DocTest:
             if self.mode == 'pytest':
                 import pytest
 
-                pytest.skip()
+                pytest.skip(self._skip_reason())
 
         summary = self._post_run(verbose)
 

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -315,7 +315,7 @@ class XDoctestItem(pytest.Item):
         # verbose = self.dtest.config['verbose']
         self.dtest.run(on_error='raise')
         if not self.dtest.anything_ran():
-            pytest.skip('doctest is empty or all parts were skipped')
+            pytest.skip(self.dtest._skip_reason())
 
     def repr_failure(self, excinfo):  # type: ignore
         """

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -901,3 +901,93 @@ def test_requirement_check_without_packaging(monkeypatch) -> None:
     )
     with pytest.warns(RuntimeWarning, match='packaging is required'):
         assert not doctest_example._doctest_requirement_satisfied('pytest>=1')
+
+
+def test_static_module_metadata_cache_reuses_and_invalidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xdoctest import doctest_example as mod
+
+    fpath = tmp_path / 'cached_metadata.py'
+    fpath.write_text("__doctest_skip__ = ['first']\n")
+
+    calls: list[str] = []
+    original = mod.static.parse_static_value
+
+    def counting_parse(key: str, *, fpath: str) -> typing.Any:
+        calls.append(key)
+        return original(key, fpath=fpath)
+
+    monkeypatch.setattr(mod.static, 'parse_static_value', counting_parse)
+    mod._read_static_module_doctest_metadata_cached.cache_clear()
+    try:
+        first = mod._static_module_doctest_metadata(fpath)
+        second = mod._static_module_doctest_metadata(fpath)
+        assert second is first
+        assert calls == ['__doctest_skip__', '__doctest_requires__']
+
+        fpath.write_text("__doctest_skip__ = ['second', 'changed']\n")
+        changed = mod._static_module_doctest_metadata(fpath)
+        assert changed[0] == ['second', 'changed']
+        assert calls == [
+            '__doctest_skip__',
+            '__doctest_requires__',
+            '__doctest_skip__',
+            '__doctest_requires__',
+        ]
+    finally:
+        mod._read_static_module_doctest_metadata_cached.cache_clear()
+
+
+def test_module_metadata_returns_specific_skip_reasons() -> None:
+    import types
+
+    from xdoctest import directive, doctest_example
+
+    module = types.ModuleType('metadata_reason_demo')
+    setattr(module, '__doctest_skip__', ['skip_me'])
+    setattr(
+        module,
+        '__doctest_requires__',
+        {'needs_missing': ['definitely_missing_package_123456']},
+    )
+
+    skipped = doctest_example.DocTest(
+        docsrc='>>> 1\n2\n',
+        modpath=module,
+        callname='skip_me',
+    )
+    skip_state = directive.RuntimeState()
+    reason = skipped._apply_module_doctest_metadata(skip_state)
+    assert reason == 'listed in `__doctest_skip__`'
+    assert skip_state['SKIP']
+
+    required = doctest_example.DocTest(
+        docsrc='>>> 1\n1\n',
+        modpath=module,
+        callname='needs_missing',
+    )
+    require_state = directive.RuntimeState()
+    reason = required._apply_module_doctest_metadata(require_state)
+    assert reason == (
+        "unmet `__doctest_requires__` requirement: "
+        "'definitely_missing_package_123456'"
+    )
+    assert require_state['SKIP']
+
+
+def test_module_requirement_patterns_validate_sequence_items() -> None:
+    import types
+
+    import pytest
+
+    from xdoctest import doctest_example
+
+    module = types.ModuleType('metadata_validation_demo')
+    dtest = doctest_example.DocTest(
+        docsrc='>>> 1\n1\n',
+        modpath=module,
+        callname='target',
+    )
+    with pytest.raises(ValueError, match='patterns must be strings'):
+        dtest._unmet_module_requirement({('target', 3): ['os']})

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1576,6 +1576,40 @@ class TestXDoctestModuleMetadata:
         reprec = testdir.inline_run('--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(passed=1, skipped=2)
 
+
+    def test_metadata_skip_reason_is_reported(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        testdir.makepyfile(
+            meta=utils.codeblock(
+                """
+                __doctest_skip__ = ['skip_me']
+                __doctest_requires__ = {
+                    'needs_missing': ['definitely_missing_package_123456'],
+                }
+
+                def skip_me():
+                    '''
+                    >>> 1
+                    2
+                    '''
+
+                def needs_missing():
+                    '''
+                    >>> 1
+                    1
+                    '''
+                """
+            )
+        )
+        result = testdir.runpytest(
+            '--xdoctest-modules', '-rs', *EXTRA_ARGS
+        )
+        result.stdout.fnmatch_lines(['*listed in `__doctest_skip__`*'])
+        result.stdout.fnmatch_lines(
+            ['*unmet `__doctest_requires__` requirement*']
+        )
+
     def test_doctestplus_requires_metadata(
         self, testdir: pytest.Testdir
     ) -> None:


### PR DESCRIPTION
## What changed

- Rebuilds this rung directly on the merged #212 `main`, dropping all obsolete checker-fast-path changes from the old stacked branch.
- Caches static `__doctest_skip__` and `__doctest_requires__` reads across doctests from the same unchanged module.
- Keys the bounded cache by canonical path plus file modification time, change time, and size, so edited modules are reparsed instead of returning stale pathname-only results.
- Keeps loaded module attributes authoritative, preserving dynamically computed metadata.
- Accepts `types.ModuleType` at the constructor boundary, retains it in `self.module`, and normalizes `self.modpath` / `self.fpath` back to path-only invariants for all downstream filesystem operations.
- Returns and retains concrete metadata skip reasons for pytest reporting.
- Reports the exact unmet `__doctest_requires__` requirement and distinguishes it from an explicit `__doctest_skip__` match.
- Uses one shared skip-reason path from both `DocTest.run()` and the pytest item fallback.
- Validates non-string requirement patterns explicitly and makes set-based pattern and requirement traversal deterministic.
- Adds a concise dogfooding doctest for cache reuse and invalidation, focused unit coverage, and a pytest reporting regression.

## Why

The existing runner already evaluates module metadata once per `DocTest.run`; the expensive part was repeated static parsing across multiple doctests from the same source file. A pathname-only process cache is not sufficient because long-lived processes, watch modes, and tests may edit a module in place. File-identity-aware caching retains the optimization without making stale metadata authoritative.

Concrete skip reasons also make `pytest -rs` useful: users can see whether a doctest was explicitly listed for skipping or which dependency requirement was unmet.

## Validation

The guarded publisher runs:

- focused `DocTest` unit tests;
- the new cache doctest;
- a direct pytest-plugin smoke test that verifies both reported skip reasons;
- Python 3.8 grammar parsing for every changed Python file;
- `compileall` and `git diff --check`;
- mypy, ty, and fatal flake8 selectors when available.
