### PR TITLE
Make xdoctest pytest items safe for embedding

### DIFF
--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -201,9 +201,40 @@ def _pytest_collect_file(file_path, parent, **path_args):
             return XDoctestTextfile(file_path, parent)
 
 
+def _lookup_xdoctest_namespace(
+    getfixturevalue: typing.Callable[[str], typing.Any],
+) -> dict[str, object]:
+    """Resolve xdoctest's optional namespace without hiding fixture errors."""
+    try:
+        namespace = getfixturevalue('xdoctest_namespace')
+    except fixtures.FixtureLookupError as ex:
+        if ex.argname != 'xdoctest_namespace':
+            raise
+        return {}
+    return dict(namespace)
+
+
+def _doctestplus_owns_textfile(config: pytest.Config, path: typing.Any) -> bool:
+    """Check whether the active pytest-doctestplus collector owns ``path``.
+
+    ``pytest_doctestplus`` is the package entry-point name. The enabled
+    collector is registered separately as ``doctestplus`` and owns only files
+    matched by pytest's standard ``doctestglob`` option.
+    """
+    if not config.pluginmanager.hasplugin('doctestplus'):
+        return False
+    globs = getattr(config.option, 'doctestglob', ()) or ()
+    return any(_match(path, glob) for glob in globs)
+
+
 def _is_xdoctest(config, path, parent):
     matched = False
-    if _suffix(path) in ('.txt', '.rst') and parent.session.isinitpath(path):
+    suffix = _suffix(path)
+    if suffix in ('.txt', '.rst') and _doctestplus_owns_textfile(
+        config, path
+    ):
+        return False
+    if suffix in ('.txt', '.rst') and parent.session.isinitpath(path):
         matched = True
     else:
         globs = config.getoption('xdoctestglob')
@@ -291,21 +322,25 @@ class XDoctestItem(pytest.Item):
     def setup(self) -> None:
         if _PYTEST_IS_GE_800:
             self._request._fillfixtures()
-            globs = dict(getfixture=self._request.getfixturevalue)
-            for name, value in self._request.getfixturevalue(
-                'xdoctest_namespace'
-            ).items():
+            globs: dict[str, object] = {
+                'getfixture': self._request.getfixturevalue
+            }
+            namespace = _lookup_xdoctest_namespace(
+                self._request.getfixturevalue
+            )
+            for name, value in namespace.items():
                 globs[name] = value
             self.dtest.globs.update(globs)
         else:
             if self.dtest is not None:
                 self.fixture_request = _setup_fixtures(self)  # type: ignore
-                global_namespace = dict(
-                    getfixture=self.fixture_request.getfixturevalue  # type: ignore
+                global_namespace: dict[str, object] = {
+                    'getfixture': self.fixture_request.getfixturevalue  # type: ignore
+                }
+                namespace = _lookup_xdoctest_namespace(
+                    self.fixture_request.getfixturevalue  # type: ignore
                 )
-                for name, value in self.fixture_request.getfixturevalue(  # type: ignore
-                    'xdoctest_namespace'
-                ).items():
+                for name, value in namespace.items():
                     global_namespace[name] = value
                 self.dtest.global_namespace.update(global_namespace)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2231,3 +2231,181 @@ class Disabled:
         items, reprec = testdir.inline_genitems(p, '--xdoctest-modules')
         reportinfo = items[0].reportinfo()
         assert reportinfo[1] == 1
+
+
+class TestPytestEmbedding:
+    @pytest.fixture(autouse=True)
+    def _disable_plugin_autoload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv('PYTEST_DISABLE_PLUGIN_AUTOLOAD', '1')
+
+    def test_namespace_fixture_with_normal_plugin(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        testdir.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture
+            def xdoctest_namespace():
+                return {'embedded_value': 42}
+            """
+        )
+        testdir.makepyfile(
+            sample="""
+            def check_namespace():
+                '''
+                >>> embedded_value
+                42
+                '''
+            """
+        )
+        result = testdir.inline_run(
+            '--xdoctest-modules', '-p', 'xdoctest.plugin', *EXTRA_ARGS
+        )
+        result.assertoutcome(passed=1)
+
+    def test_namespace_fixture_dependency_error_is_not_hidden(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        testdir.makeconftest(
+            """
+            import pytest
+
+            @pytest.fixture
+            def xdoctest_namespace(missing_namespace_dependency):
+                return {}
+            """
+        )
+        testdir.makepyfile(
+            sample="""
+            def check_namespace():
+                '''
+                >>> 1 + 1
+                2
+                '''
+            """
+        )
+        result = testdir.runpytest(
+            '--xdoctest-modules',
+            '-q',
+            '-p',
+            'xdoctest.plugin',
+            *EXTRA_ARGS,
+        )
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(
+            ["*fixture 'missing_namespace_dependency' not found*"]
+        )
+
+    def test_embedded_item_without_namespace_fixture(
+        self, testdir: pytest.Testdir, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        testdir.makeconftest(
+            """
+            from pathlib import Path
+
+            import pytest
+
+            from xdoctest.doctest_example import DocTest
+            from xdoctest.plugin import XDoctestItem
+
+
+            class EmbeddedFile(pytest.File):
+                def collect(self):
+                    node_path = getattr(self, 'path', None)
+                    if node_path is None:
+                        node_path = self.fspath
+                    dtest = DocTest(
+                        docsrc='>>> 1 + 1\\n2',
+                        callname='embedded',
+                        lineno=1,
+                        fpath=str(node_path),
+                        mode='pytest',
+                    )
+                    yield XDoctestItem.from_parent(
+                        self, name='embedded', dtest=dtest
+                    )
+
+
+            if pytest.__version__ < '7.':
+                def pytest_collect_file(path, parent):
+                    if path.ext == '.embed':
+                        return EmbeddedFile.from_parent(parent, fspath=path)
+            else:
+                def pytest_collect_file(file_path, parent):
+                    if file_path.suffix == '.embed':
+                        return EmbeddedFile.from_parent(
+                            parent, path=Path(file_path)
+                        )
+            """
+        )
+        testdir.makefile('.embed', embedded='placeholder')
+        source_root = Path(__file__).resolve().parents[1] / 'src'
+        monkeypatch.setenv('PYTHONPATH', str(source_root))
+        result = testdir.runpytest_subprocess('-q')
+        result.assert_outcomes(passed=1)
+
+    def test_installed_doctestplus_owns_rst_textfile(
+        self, testdir: pytest.Testdir, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip('pytest_doctestplus')
+        path = testdir.makefile(
+            '.rst',
+            narrative="""
+            .. doctest-skip::
+
+                >>> raise RuntimeError('doctestplus should skip this')
+            """,
+        )
+        source_root = Path(__file__).resolve().parents[1] / 'src'
+        monkeypatch.setenv('PYTHONPATH', str(source_root))
+        result = testdir.runpytest_subprocess(
+            path,
+            '-p',
+            'xdoctest.plugin',
+            '-p',
+            'pytest_doctestplus.plugin',
+            '--doctest-plus',
+            '--doctest-glob=*.rst',
+            '--xdoctest-glob=*.rst',
+            '-q',
+            '-rs',
+        )
+        result.assert_outcomes(skipped=1)
+
+    def test_doctestplus_textfile_ownership_detection(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        from types import SimpleNamespace
+        from typing import Any, List, Set
+
+        from xdoctest.plugin import _doctestplus_owns_textfile
+
+        class FakePluginManager:
+            def __init__(self, plugin_names: Set[str]) -> None:
+                self.plugin_names = plugin_names
+
+            def hasplugin(self, name: str) -> bool:
+                return name in self.plugin_names
+
+        def make_config(
+            plugin_names: Set[str], doctest_globs: List[str]
+        ) -> Any:
+            return SimpleNamespace(
+                pluginmanager=FakePluginManager(plugin_names),
+                option=SimpleNamespace(doctestglob=doctest_globs),
+            )
+
+        if pytest.__version__ < '7.':
+            path = testdir.tmpdir.join(Path('narrative.txt'))
+        else:
+            path = Path('narrative.txt')
+        loader_only = make_config({'pytest_doctestplus'}, ['*.txt'])
+        active_match = make_config({'doctestplus'}, ['*.txt'])
+        active_mismatch = make_config({'doctestplus'}, ['*.rst'])
+
+        assert not _doctestplus_owns_textfile(loader_only, path)
+        assert _doctestplus_owns_textfile(active_match, path)
+        assert not _doctestplus_owns_textfile(active_mismatch, path)


### PR DESCRIPTION
## What changed

- Allows `XDoctestItem` to be embedded when the optional `xdoctest_namespace` fixture is not registered.
- Preserves real fixture dependency failures instead of swallowing every `FixtureLookupError`.
- Defers `.rst` and `.txt` collection only when the active pytest-doctestplus collector actually owns the path through pytest's standard doctest globs.
- Rebuilds the PR directly on current `main`, excluding stale checker-lifecycle and module-metadata implementations inherited by the old stacked branch.
- Keeps the embedding tests executable across the pytest 6 / Python 3.8 and current-pytest lanes.

## Pytest compatibility corrections

- The embedded collector resolves `path` on modern pytest and falls back to legacy `fspath` instead of assuming either API or using a platform-sensitive relative filename.
- The text-file ownership unit test passes pytest's real legacy `py.path` type on pytest 6 and `pathlib.Path` on pytest 7+, matching the production hook boundary.
- Runtime annotations in the tests remain Python 3.8-safe.

## Skip behavior

Current `main` already contains the accepted #213 behavior: `DocTest.run()` reports full skips with the most concrete metadata reason, and `XDoctestItem.runtest()` retains the empty-run fallback. This PR deliberately leaves that centralized behavior unchanged rather than adding a second skip path.

## Validation

- The complete pytest embedding/coexistence group passes in the available environment; the real pytest-doctestplus case skips when that package is absent.
- An explicit legacy pytest ownership probe exercises the `py.path.check(fnmatch=...)` branch.
- The publisher runs the complete embedding group under `python3.8` when available.
- The publisher requires `mypy src/xdoctest`, `ty check src/xdoctest tests/`, fatal flake8 selectors, and `git diff --check` before publication.

- Uses a real `PathLike` argument for legacy `py.path.local.join`, satisfying both pytest 6 runtime behavior and current `ty` stubs.
