### PR TITLE
Add the stdlib doctest adapter package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `__doctest_requires__` metadata. Bare module or distribution requirements
   remain zero-dependency; version-constrained requirements use the optional
   `packaging` dependency.
+* Added `xdoctest.stdlib_doctest`, the documented adapter package for
+  stdlib `doctest` objects, checkers, and option flags. It exposes checker
+  and optionflag registration,
+  runtime-state conversion, structured stdlib-doctest intake helpers, and the
+  supporting `StdlibExampleLike`, `RuntimeState`, and `DocTest` types used by
+  those public signatures.
 
 ### Fixed
 * Fixed issue #181 where comment indentation could cause parsing issues.

--- a/docs/source/auto/xdoctest.rst
+++ b/docs/source/auto/xdoctest.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    xdoctest.docstr
+   xdoctest.stdlib_doctest
    xdoctest.utils
 
 Submodules

--- a/docs/source/auto/xdoctest.stdlib_doctest.rst
+++ b/docs/source/auto/xdoctest.stdlib_doctest.rst
@@ -1,0 +1,50 @@
+xdoctest.stdlib_doctest package
+===============================
+
+.. automodule:: xdoctest.stdlib_doctest
+
+Supporting types
+----------------
+
+.. autoclass:: xdoctest.stdlib_doctest.StdlibExampleLike
+   :noindex:
+   :show-inheritance:
+
+.. autoclass:: xdoctest.stdlib_doctest.RuntimeState
+   :noindex:
+   :show-inheritance:
+
+.. autoclass:: xdoctest.stdlib_doctest.DocTest
+   :noindex:
+   :show-inheritance:
+
+.. autoclass:: xdoctest.stdlib_doctest.OutputChecker
+   :noindex:
+   :show-inheritance:
+
+Registration
+------------
+
+.. autofunction:: xdoctest.stdlib_doctest.register_optionflag
+   :noindex:
+
+.. autofunction:: xdoctest.stdlib_doctest.register_checker
+   :noindex:
+
+.. autofunction:: xdoctest.stdlib_doctest.resolve_checker
+   :noindex:
+
+Conversion
+----------
+
+.. autofunction:: xdoctest.stdlib_doctest.optionflags_to_runtime_state
+   :noindex:
+
+.. autofunction:: xdoctest.stdlib_doctest.runtime_state_to_optionflags
+   :noindex:
+
+.. autofunction:: xdoctest.stdlib_doctest.from_examples
+   :noindex:
+
+.. autofunction:: xdoctest.stdlib_doctest.from_stdlib_doctest
+   :noindex:

--- a/src/xdoctest/__init__.py
+++ b/src/xdoctest/__init__.py
@@ -318,10 +318,11 @@ __version__ = '1.3.3'
 __submodules__ = [
     'runner',
     'exceptions',
+    'stdlib_doctest',
 ]
 
 
-from xdoctest import docstr, utils
+from xdoctest import docstr, stdlib_doctest, utils
 from xdoctest.exceptions import (
     DoctestParseError,
     ExistingEventLoopError,
@@ -332,7 +333,7 @@ from xdoctest.runner import (
     doctest_callable,
     doctest_module,
 )
-from xdoctest.directive_facade import (
+from xdoctest.stdlib_doctest import (
     BLANKLINE_MARKER,
     DONT_ACCEPT_BLANKLINE,
     ELLIPSIS,
@@ -345,19 +346,17 @@ from xdoctest.directive_facade import (
     IGNORE_WANT,
     NORMALIZE_REPR,
     NORMALIZE_WHITESPACE,
+    OutputChecker,
     REPORT_CDIFF,
     REPORT_NDIFF,
     REPORT_UDIFF,
     SHOW_WARNINGS,
     SKIP,
     optionflags_to_runtime_state,
-    register_optionflag,
-    runtime_state_to_optionflags,
-)
-from xdoctest.checker_facade import (
-    OutputChecker,
     register_checker,
+    register_optionflag,
     resolve_checker,
+    runtime_state_to_optionflags,
 )
 
 __all__ = [
@@ -369,6 +368,7 @@ __all__ = [
     'doctest_callable',
     'utils',
     'docstr',
+    'stdlib_doctest',
     '__version__',
     'BLANKLINE_MARKER',
     'ELLIPSIS_MARKER',

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -298,14 +298,27 @@ def _coerce_runstate(
         return runstate
     if runstate is None:
         return directive.RuntimeState()
-    from xdoctest import checker_facade
+    from xdoctest.stdlib_doctest import _checker, _optionflags
 
-    optionflags = checker_facade.runtime_state_to_optionflags(runstate)
-    normalized = checker_facade.optionflags_to_runtime_state(optionflags)
+    optionflags = _optionflags.runtime_state_to_optionflags(runstate)
+    normalized = _optionflags.optionflags_to_runtime_state(optionflags)
     normalized.set_output_checker(
         str(runstate.get('_output_checker', 'xdoctest'))
     )
     return normalized
+
+
+def _stdlib_checker_want(want: str) -> str:
+    """Restore the line ending expected by stdlib output checkers.
+
+    Xdoctest stores parsed wants without a trailing newline, while
+    :mod:`doctest` passes non-empty ``Example.want`` values to output
+    checkers with their terminating newline intact. Foreign checkers use the
+    stdlib protocol, so normalize only at that boundary.
+    """
+    if want and not want.endswith('\n'):
+        return want + '\n'
+    return want
 
 
 def check_output(
@@ -336,10 +349,14 @@ def check_output(
     checker_name = runstate.get_output_checker()
     if checker_name == 'xdoctest':
         return _xdoctest_check_output(got, want, runstate)
-    from xdoctest import checker_facade
-    optionflags = checker_facade.runtime_state_to_optionflags(runstate)
-    output_checker = checker_facade.resolve_checker(checker_name, runstate)
-    return bool(output_checker.check_output(want, got, optionflags))
+    from xdoctest.stdlib_doctest import _checker, _optionflags
+    optionflags = _optionflags.runtime_state_to_optionflags(runstate)
+    output_checker = _checker.resolve_checker(checker_name, runstate)
+    return bool(
+        output_checker.check_output(
+            _stdlib_checker_want(want), got, optionflags
+        )
+    )
 
 
 def _check_match(
@@ -843,16 +860,18 @@ class GotWantException(AssertionError):
             # A foreign checker may provide its own difference rendering
             # (e.g. to display fixed-up wants); fall back to the native
             # renderer when it inherits the facade default.
-            from xdoctest import checker_facade
-            output_checker = checker_facade.resolve_checker(
+            from xdoctest.stdlib_doctest import _checker, _optionflags
+            output_checker = _checker.resolve_checker(
                 checker_name, runstate
             )
             if (
                 output_checker.__class__.output_difference
-                is not checker_facade.OutputChecker.output_difference
+                is not _checker.OutputChecker.output_difference
             ):
-                example = doctest.Example(source='', want=self.want)
-                optionflags = checker_facade.runtime_state_to_optionflags(
+                example = doctest.Example(
+                    source='', want=_stdlib_checker_want(self.want)
+                )
+                optionflags = _optionflags.runtime_state_to_optionflags(
                     runstate
                 )
                 return output_checker.output_difference(

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -517,10 +517,10 @@ class RuntimeState(utils.NiceRepr):
                     continue
 
                 if key not in self._global_state:
-                    from xdoctest import directive_facade
+                    from xdoctest.stdlib_doctest import _optionflags
 
-                    if directive_facade.is_registered_optionflag(key):
-                        flag = directive_facade.get_optionflag(key)
+                    if _optionflags.is_registered_optionflag(key):
+                        flag = _optionflags.get_optionflag(key)
                         if action == 'assign':
                             if value:
                                 self.add_output_checker_flags(flag, inline=bool(directive.inline))
@@ -1127,9 +1127,9 @@ def parse_directive_optstr(
 
     name = name.upper()
     if name not in COMMANDS:
-        from xdoctest import directive_facade
+        from xdoctest.stdlib_doctest import _optionflags
 
-        if not directive_facade.is_registered_optionflag(name):
+        if not _optionflags.is_registered_optionflag(name):
             msg = 'Unknown directive: {!r}'.format(optpart)
             warnings.warn(msg)
             return None

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -1311,10 +1311,10 @@ class DocTest:
         # state so local negative directives can override configured defaults;
         # only checker-specific flags remain in the raw bitmask.
         default_state = self.config['default_runtime_state']
-        from xdoctest import directive_facade
+        from xdoctest.stdlib_doctest import _optionflags
 
         native_defaults = directive.RuntimeState(default_state).to_dict()
-        runstate = self._runstate = directive_facade.optionflags_to_runtime_state(
+        runstate = self._runstate = _optionflags.optionflags_to_runtime_state(
             int(self.config.get('output_checker_flags', 0)),
             cast(directive.RuntimeStateDict, native_defaults),
         )
@@ -1504,7 +1504,7 @@ class DocTest:
                             finally:
                                 asyncio_runner = None
                         # Execute the doctest code. ``_part_context`` is an
-                        # extension point used by the stdlib_compat intake
+                        # extension point used by the stdlib-doctest intake
                         # seam to apply per-part warning policy without
                         # rewriting source. Default is a no-op.
                         try:

--- a/src/xdoctest/stdlib_doctest/__init__.py
+++ b/src/xdoctest/stdlib_doctest/__init__.py
@@ -1,0 +1,147 @@
+r"""
+Adapter API for stdlib :mod:`doctest` objects and protocols.
+
+Tools that already produce or consume stdlib :mod:`doctest` objects can use
+this package to run them through xdoctest without depending on the layout of
+the private adapter modules.
+
+Quick start
+-----------
+
+A third-party collector that already produces stdlib :mod:`doctest` objects
+can register its checker and pass those objects directly to xdoctest:
+
+Example:
+    >>> import doctest
+    >>> import xdoctest.stdlib_doctest as stdlib_doctest
+    >>> fix = stdlib_doctest.register_optionflag('_STDLIB_DOCTEST_DOCS_FIX')
+    >>> class ThirdPartyChecker(stdlib_doctest.OutputChecker):
+    ...     def check_output(self, want, got, optionflags):
+    ...         if optionflags & fix:
+    ...             want = want.replace('L', '')
+    ...             got = got.replace('L', '')
+    ...         return super().check_output(want, got, optionflags)
+    >>> checker_name = '_stdlib_doctest_docs_checker'
+    >>> stdlib_doctest.register_checker(checker_name, ThirdPartyChecker)
+    >>> example = doctest.Example(
+    ...     source='print("10")\n',
+    ...     want='10L\n',
+    ...     lineno=0,
+    ...     options={fix: True},
+    ... )
+    >>> converted = stdlib_doctest.from_examples(
+    ...     [example],
+    ...     name='third-party-example',
+    ...     config={'output_checker': checker_name},
+    ... )
+    >>> isinstance(converted, stdlib_doctest.DocTest)
+    True
+    >>> converted.run(verbose=0, on_error='raise')['passed']
+    True
+
+Registration
+------------
+
+``register_optionflag``
+    Register a stdlib-style option flag by name, optionally binding it to an
+    xdoctest runtime-state key. The returned bit is shared with
+    :func:`doctest.register_optionflag`.
+
+``register_checker``
+    Register a stdlib-shaped output checker under a configuration name.
+    Select it for a test with ``DocTest.config['output_checker']``.
+
+``resolve_checker``
+    Resolve the native checker or a previously registered foreign checker.
+
+Conversion
+----------
+
+``optionflags_to_runtime_state`` and ``runtime_state_to_optionflags``
+    Convert between stdlib option-flag integers and xdoctest's structured
+    runtime state.
+
+``from_examples`` and ``from_stdlib_doctest``
+    Convert stdlib-shaped examples or a complete :class:`doctest.DocTest`
+    into a runnable :class:`DocTest` while preserving source locations,
+    namespaces, option boundaries, and expected output.
+
+Supporting types
+----------------
+
+``StdlibExampleLike``
+    Structural protocol accepted by :func:`from_examples`.
+
+``RuntimeState``
+    Structured runtime state accepted and returned by the conversion helpers.
+
+``DocTest``
+    Runnable xdoctest object returned by the intake helpers.
+
+``OutputChecker``
+    xdoctest's native matcher exposed through the stdlib checker interface for
+    composition by foreign checkers.
+
+The overlapping registration, conversion, checker, and optionflag names remain
+available at the top-level :mod:`xdoctest` namespace for compatibility. This
+package is the documented home of the stdlib-doctest adapter.
+"""
+
+from xdoctest.directive import RuntimeState
+from xdoctest.doctest_example import DocTest
+
+from ._checker import OutputChecker, register_checker, resolve_checker
+from ._convert import StdlibExampleLike, from_examples, from_stdlib_doctest
+from ._optionflags import (
+    BLANKLINE_MARKER,
+    DONT_ACCEPT_BLANKLINE,
+    ELLIPSIS,
+    ELLIPSIS_MARKER,
+    FLOAT_CMP,
+    IGNORE_EXCEPTION_DETAIL,
+    IGNORE_OUTPUT,
+    IGNORE_WARNINGS,
+    IGNORE_WHITESPACE,
+    IGNORE_WANT,
+    NORMALIZE_REPR,
+    NORMALIZE_WHITESPACE,
+    REPORT_CDIFF,
+    REPORT_NDIFF,
+    REPORT_UDIFF,
+    SHOW_WARNINGS,
+    SKIP,
+    optionflags_to_runtime_state,
+    register_optionflag,
+    runtime_state_to_optionflags,
+)
+
+__all__ = [
+    'BLANKLINE_MARKER',
+    'DONT_ACCEPT_BLANKLINE',
+    'DocTest',
+    'ELLIPSIS',
+    'ELLIPSIS_MARKER',
+    'FLOAT_CMP',
+    'IGNORE_EXCEPTION_DETAIL',
+    'IGNORE_OUTPUT',
+    'IGNORE_WARNINGS',
+    'IGNORE_WHITESPACE',
+    'IGNORE_WANT',
+    'NORMALIZE_REPR',
+    'NORMALIZE_WHITESPACE',
+    'OutputChecker',
+    'REPORT_CDIFF',
+    'REPORT_NDIFF',
+    'REPORT_UDIFF',
+    'RuntimeState',
+    'SHOW_WARNINGS',
+    'SKIP',
+    'StdlibExampleLike',
+    'from_examples',
+    'from_stdlib_doctest',
+    'optionflags_to_runtime_state',
+    'register_checker',
+    'register_optionflag',
+    'resolve_checker',
+    'runtime_state_to_optionflags',
+]

--- a/src/xdoctest/stdlib_doctest/_checker.py
+++ b/src/xdoctest/stdlib_doctest/_checker.py
@@ -1,5 +1,5 @@
 """
-Stdlib-doctest-shaped façade over xdoctest's checker.
+Stdlib-doctest-shaped checker adapter for xdoctest.
 
 This module exposes a small public surface that lets tooling built around the
 stdlib :mod:`doctest` module (most notably :mod:`pytest_doctestplus`) plug
@@ -8,8 +8,7 @@ into xdoctest's runner without having to know about xdoctest's internal
 
 Adopters typically:
 
-1. Register their optionflags through :func:`xdoctest.register_optionflag`
-   (re-exported here from :mod:`xdoctest.directive_facade`).
+1. Register their optionflags through :func:`xdoctest.stdlib_doctest.register_optionflag`.
 2. Define an :class:`OutputChecker` subclass with the standard
    ``check_output(want, got, optionflags)`` and (optionally)
    ``output_difference(example, got, optionflags)`` signatures.
@@ -28,7 +27,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 from xdoctest import checker, directive
-from xdoctest.directive_facade import (
+from ._optionflags import (
     optionflags_to_runtime_state,
     register_optionflag,
     runtime_state_to_optionflags,
@@ -176,7 +175,7 @@ class OutputChecker(doctest.OutputChecker):
         replacement for stdlib-shaped consumers.
 
     Example:
-        >>> from xdoctest.directive_facade import ELLIPSIS, FLOAT_CMP
+        >>> from xdoctest.stdlib_doctest import ELLIPSIS, FLOAT_CMP
         >>> output_checker = OutputChecker()
         >>> output_checker.check_output(
         >>>     'prefix ... value=1\n',
@@ -209,7 +208,4 @@ __all__ = [
     'register_checker',
     'resolve_checker',
     'resolve_current_checker',
-    'register_optionflag',
-    'runtime_state_to_optionflags',
-    'optionflags_to_runtime_state',
 ]

--- a/src/xdoctest/stdlib_doctest/_convert.py
+++ b/src/xdoctest/stdlib_doctest/_convert.py
@@ -43,7 +43,9 @@ import os
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
 
-from xdoctest import directive, directive_facade, parser
+from xdoctest import directive, parser
+
+from . import _optionflags
 from xdoctest.doctest_example import DocTest
 from xdoctest.doctest_part import DoctestPart
 
@@ -312,8 +314,8 @@ def _apply_stdlib_optionflags(dtest: DocTest, optionflags: int) -> None:
     defaults = dict(dtest.config.get('default_runtime_state') or {})
     runtime_bound_mask = 0
     for key in directive.DEFAULT_RUNTIME_STATE:
-        if directive_facade.is_registered_optionflag(key):
-            flag = directive_facade.get_optionflag(key)
+        if _optionflags.is_registered_optionflag(key):
+            flag = _optionflags.get_optionflag(key)
             runtime_bound_mask |= flag
             defaults[key] = bool(optionflags & flag)
     dtest.config['default_runtime_state'] = defaults
@@ -321,9 +323,9 @@ def _apply_stdlib_optionflags(dtest: DocTest, optionflags: int) -> None:
 
     dtest.config['reportchoice'] = 'none'
     report_flags = [
-        (directive_facade.REPORT_UDIFF, 'udiff'),
-        (directive_facade.REPORT_CDIFF, 'cdiff'),
-        (directive_facade.REPORT_NDIFF, 'ndiff'),
+        (_optionflags.REPORT_UDIFF, 'udiff'),
+        (_optionflags.REPORT_CDIFF, 'cdiff'),
+        (_optionflags.REPORT_NDIFF, 'ndiff'),
     ]
     for flag, reportchoice in report_flags:
         if optionflags & flag:
@@ -392,11 +394,11 @@ def _options_to_directives(
         name = name.upper()
         if (
             name not in directive.COMMANDS
-            and not directive_facade.is_registered_optionflag(name)
+            and not _optionflags.is_registered_optionflag(name)
         ):
             # Adopt any stdlib-registered flag so the directive system can
             # carry it through to the output checker as a checker-only bit.
-            directive_facade.register_optionflag(name)
+            _optionflags.register_optionflag(name)
         directives.append(
             directive.Directive(name, positive=bool(value), inline=True)
         )

--- a/src/xdoctest/stdlib_doctest/_optionflags.py
+++ b/src/xdoctest/stdlib_doctest/_optionflags.py
@@ -254,7 +254,7 @@ def optionflags_to_runtime_state(
 
 
 def is_registered_optionflag(name: str) -> bool:
-    """Check whether an optionflag name is known to the facade.
+    """Check whether an optionflag name is known to the stdlib-doctest adapter.
 
     Example:
         >>> is_registered_optionflag('ELLIPSIS')

--- a/tests/test_checker_compat.py
+++ b/tests/test_checker_compat.py
@@ -8,17 +8,17 @@ from typing import NoReturn
 import pytest
 
 import xdoctest
-from xdoctest import checker, checker_facade, directive, doctest_example, utils
-from xdoctest import directive_facade
+from xdoctest import checker, directive, doctest_example, stdlib_doctest, utils
+from xdoctest.stdlib_doctest import _checker, _optionflags
 
 
 @pytest.fixture(autouse=True)
-def isolate_interop_registries() -> Iterator[None]:
-    """Restore every process-global interop registry after each test."""
-    checker_registry = checker_facade._REGISTERED_CHECKERS
+def isolate_stdlib_doctest_registries() -> Iterator[None]:
+    """Restore every process-global stdlib-doctest registry after each test."""
+    checker_registry = _checker._REGISTERED_CHECKERS
     checker_snapshot = checker_registry.copy()
 
-    runtime_flags = directive_facade._RUNTIME_FLAGS
+    runtime_flags = _optionflags._RUNTIME_FLAGS
     runtime_flags_snapshot = copy.deepcopy(runtime_flags.__dict__)
 
     doctest_flags = doctest.OPTIONFLAGS_BY_NAME
@@ -110,7 +110,7 @@ def test_registered_checker_receives_runtime_state_flags() -> None:
     result = self.run(verbose=0, on_error='raise')
     assert result['passed']
     assert seen
-    assert seen[-1] & directive_facade.FLOAT_CMP
+    assert seen[-1] & _optionflags.FLOAT_CMP
 
 
 def test_registered_checker_output_difference_is_used() -> None:
@@ -164,7 +164,7 @@ def test_resolve_current_checker_honors_mapping_state() -> None:
         pass
 
     xdoctest.register_checker('mapping_checker', MappingChecker)
-    resolved = xdoctest.checker_facade.resolve_current_checker(
+    resolved = _checker.resolve_current_checker(
         {'_output_checker': 'mapping_checker'}
     )
     assert isinstance(resolved, MappingChecker)
@@ -426,13 +426,13 @@ def test_output_checker_honors_ignore_output() -> None:
 
 def test_native_checker_name_is_reserved() -> None:
     with pytest.raises(ValueError, match='reserved'):
-        checker_facade.register_checker('xdoctest', doctest.OutputChecker)
+        _checker.register_checker('xdoctest', doctest.OutputChecker)
 
     assert isinstance(
-        checker_facade.resolve_checker('xdoctest'),
-        checker_facade.OutputChecker,
+        _checker.resolve_checker('xdoctest'),
+        _checker.OutputChecker,
     )
-    assert 'xdoctest' not in checker_facade._REGISTERED_CHECKERS
+    assert 'xdoctest' not in _checker._REGISTERED_CHECKERS
 
 
 def test_registered_class_retains_factory_semantics() -> None:
@@ -442,15 +442,15 @@ def test_registered_class_retains_factory_semantics() -> None:
         def __init__(self) -> None:
             Counting.instances += 1
 
-    checker_facade.register_checker('counting_factory', Counting)
-    first = checker_facade.resolve_checker('counting_factory')
-    second = checker_facade.resolve_checker('counting_factory')
+    _checker.register_checker('counting_factory', Counting)
+    first = _checker.resolve_checker('counting_factory')
+    second = _checker.resolve_checker('counting_factory')
     assert first is not second
     assert Counting.instances == 2
 
     replacement = doctest.OutputChecker()
-    checker_facade.register_checker('counting_factory', replacement)
-    assert checker_facade.resolve_checker('counting_factory') is replacement
+    _checker.register_checker('counting_factory', replacement)
+    assert _checker.resolve_checker('counting_factory') is replacement
 
 
 def test_registered_class_is_cached_per_runtime_state() -> None:
@@ -460,24 +460,24 @@ def test_registered_class_is_cached_per_runtime_state() -> None:
         def __init__(self) -> None:
             Counting.instances += 1
 
-    checker_facade.register_checker('counting_per_run', Counting)
+    _checker.register_checker('counting_per_run', Counting)
 
     first_run = directive.RuntimeState()
     first_run.set_output_checker('counting_per_run')
-    first = checker_facade.resolve_current_checker(first_run)
-    assert checker_facade.resolve_current_checker(first_run) is first
+    first = _checker.resolve_current_checker(first_run)
+    assert _checker.resolve_current_checker(first_run) is first
     assert Counting.instances == 1
 
     second_run = directive.RuntimeState()
     second_run.set_output_checker('counting_per_run')
-    second = checker_facade.resolve_current_checker(second_run)
+    second = _checker.resolve_current_checker(second_run)
     assert second is not first
     assert Counting.instances == 2
 
     # Even re-registering the same class creates a new registry generation and
     # invalidates a previously cached checker within the bounded run state.
-    checker_facade.register_checker('counting_per_run', Counting)
-    third = checker_facade.resolve_current_checker(first_run)
+    _checker.register_checker('counting_per_run', Counting)
+    third = _checker.resolve_current_checker(first_run)
     assert third is not first
     assert Counting.instances == 3
 
@@ -503,7 +503,7 @@ def test_matching_and_difference_share_one_per_run_checker() -> None:
             assert self.checked
             return 'same per-run checker'
 
-    checker_facade.register_checker('stateful_per_run', Stateful)
+    _checker.register_checker('stateful_per_run', Stateful)
     runstate = directive.RuntimeState()
     runstate.set_output_checker('stateful_per_run')
 
@@ -515,18 +515,18 @@ def test_matching_and_difference_share_one_per_run_checker() -> None:
     assert Stateful.instances == 1
 
 
-def test_native_check_bypasses_the_interop_facade(
+def test_native_check_bypasses_stdlib_doctest_adapter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The native RuntimeState path must not pack or resolve facade state."""
+    """The native RuntimeState path must not pack or resolve adapter state."""
 
     def forbidden(*args: object, **kwargs: object) -> NoReturn:
-        raise AssertionError('native path crossed the interop boundary')
+        raise AssertionError('native path crossed the stdlib-doctest boundary')
 
     monkeypatch.setattr(
-        checker_facade, 'runtime_state_to_optionflags', forbidden
+        _optionflags, 'runtime_state_to_optionflags', forbidden
     )
-    monkeypatch.setattr(checker_facade, 'resolve_checker', forbidden)
+    monkeypatch.setattr(_checker, 'resolve_checker', forbidden)
 
     runstate = directive.RuntimeState()
     assert checker.check_output('1\n', '1\n', runstate)
@@ -542,3 +542,145 @@ def test_sparse_mapping_is_normalized_before_native_matching() -> None:
     ).output_difference(sparse, colored=False)
     assert 'Expected:' in difference
     assert 'Got:' in difference
+
+
+def test_public_stdlib_doctest_namespace_contract() -> None:
+    from xdoctest import doctest_example, stdlib_doctest
+    from xdoctest.stdlib_doctest import _convert
+
+    expected = [
+        'BLANKLINE_MARKER',
+        'DONT_ACCEPT_BLANKLINE',
+        'DocTest',
+        'ELLIPSIS',
+        'ELLIPSIS_MARKER',
+        'FLOAT_CMP',
+        'IGNORE_EXCEPTION_DETAIL',
+        'IGNORE_OUTPUT',
+        'IGNORE_WARNINGS',
+        'IGNORE_WHITESPACE',
+        'IGNORE_WANT',
+        'NORMALIZE_REPR',
+        'NORMALIZE_WHITESPACE',
+        'OutputChecker',
+        'REPORT_CDIFF',
+        'REPORT_NDIFF',
+        'REPORT_UDIFF',
+        'RuntimeState',
+        'SHOW_WARNINGS',
+        'SKIP',
+        'StdlibExampleLike',
+        'from_examples',
+        'from_stdlib_doctest',
+        'optionflags_to_runtime_state',
+        'register_checker',
+        'register_optionflag',
+        'resolve_checker',
+        'runtime_state_to_optionflags',
+    ]
+    assert stdlib_doctest.__all__ == expected
+
+    # The package preserves every overlapping API currently re-exported
+    # from the top-level xdoctest namespace.
+    assert stdlib_doctest.OutputChecker is xdoctest.OutputChecker
+    assert stdlib_doctest.register_checker is xdoctest.register_checker
+    assert stdlib_doctest.resolve_checker is xdoctest.resolve_checker
+    assert stdlib_doctest.register_optionflag is xdoctest.register_optionflag
+    assert (
+        stdlib_doctest.optionflags_to_runtime_state
+        is xdoctest.optionflags_to_runtime_state
+    )
+    assert (
+        stdlib_doctest.runtime_state_to_optionflags
+        is xdoctest.runtime_state_to_optionflags
+    )
+
+    # Type-aware users can stay entirely within the public package.
+    assert stdlib_doctest.RuntimeState is directive.RuntimeState
+    assert stdlib_doctest.DocTest is doctest_example.DocTest
+    assert stdlib_doctest.StdlibExampleLike is _convert.StdlibExampleLike
+    assert stdlib_doctest.from_examples is _convert.from_examples
+    assert (
+        stdlib_doctest.from_stdlib_doctest
+        is _convert.from_stdlib_doctest
+    )
+
+
+def test_public_stdlib_doctest_preserves_stdlib_behavior() -> None:
+    """The public package accepts and executes real stdlib objects."""
+    from xdoctest import stdlib_doctest
+
+    example = doctest.Example(
+        source='print("prefix suffix")\n',
+        want='prefix ...\n',
+        lineno=3,
+        options={doctest.ELLIPSIS: True},
+    )
+    stdlib_test = doctest.DocTest(
+        examples=[example],
+        globs={'__name__': '__main__'},
+        name='package.demo',
+        filename='demo.py',
+        lineno=10,
+        docstring='',
+    )
+
+    stdlib_result = doctest.DocTestRunner().run(
+        stdlib_test,
+        out=lambda text: None,
+        clear_globs=False,
+    )
+    assert stdlib_result.failed == 0
+    assert stdlib_result.attempted == 1
+
+    stdlib_doctest.register_checker(
+        'public_stdlib_output_checker', doctest.OutputChecker
+    )
+    converted = stdlib_doctest.from_stdlib_doctest(
+        stdlib_test,
+        config={'output_checker': 'public_stdlib_output_checker'},
+    )
+    assert isinstance(converted, stdlib_doctest.DocTest)
+    assert converted.callname == stdlib_test.name
+    assert converted.lineno == 14
+    assert converted.run(verbose=0, on_error='return')['passed']
+
+
+def test_public_stdlib_doctest_checker_protocol_end_to_end() -> None:
+    """Package registration and intake obey the stdlib checker protocol."""
+    from xdoctest import stdlib_doctest
+
+    fix_flag = stdlib_doctest.register_optionflag('PUBLIC_STDLIB_DOCTEST_FIX')
+    seen: list[int] = []
+
+    class PublicStdlibDoctestChecker(stdlib_doctest.OutputChecker):
+        def check_output(
+            self, want: str, got: str, optionflags: int
+        ) -> bool:
+            seen.append(optionflags)
+            if optionflags & fix_flag:
+                want = want.replace('L', '')
+                got = got.replace('L', '')
+            return super().check_output(want, got, optionflags)
+
+    stdlib_doctest.register_checker(
+        'public_stdlib_doctest_checker', PublicStdlibDoctestChecker
+    )
+    examples = [
+        doctest.Example(
+            source='print("10")\n',
+            want='10L\n',
+            lineno=0,
+            options={fix_flag: True},
+        )
+    ]
+    converted = stdlib_doctest.from_examples(
+        examples,
+        name='public-stdlib-doctest',
+        config={'output_checker': 'public_stdlib_doctest_checker'},
+    )
+
+    assert isinstance(converted, stdlib_doctest.DocTest)
+    assert converted.run(verbose=0, on_error='return')['passed']
+    assert seen
+    assert seen[-1] & fix_flag

--- a/tests/test_stdlib_doctest.py
+++ b/tests/test_stdlib_doctest.py
@@ -9,16 +9,17 @@ from collections.abc import Iterator
 import pytest
 
 import xdoctest
-from xdoctest import checker_facade, directive_facade, stdlib_compat
+from xdoctest import stdlib_doctest
+from xdoctest.stdlib_doctest import _checker, _optionflags
 
 
 @pytest.fixture(autouse=True)
-def isolate_interop_registries() -> Iterator[None]:
+def isolate_stdlib_doctest_registries() -> Iterator[None]:
     """Restore checker and optionflag registries after each test."""
-    checker_registry = checker_facade._REGISTERED_CHECKERS
+    checker_registry = _checker._REGISTERED_CHECKERS
     checker_snapshot = checker_registry.copy()
 
-    runtime_flags = directive_facade._RUNTIME_FLAGS
+    runtime_flags = _optionflags._RUNTIME_FLAGS
     runtime_flags_snapshot = copy.deepcopy(runtime_flags.__dict__)
 
     doctest_flags = doctest.OPTIONFLAGS_BY_NAME
@@ -42,7 +43,7 @@ def isolate_interop_registries() -> Iterator[None]:
 
 def test_synthetic_example_runs_successfully():
     examples = [doctest.Example(source='print(1)\n', want='1\n', lineno=0)]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed']
     assert not result['failed']
@@ -51,7 +52,7 @@ def test_synthetic_example_runs_successfully():
 def test_synthetic_example_with_failure_reports_correct_line():
     # Stdlib Example.lineno is zero-based, so lineno=4 is physical line 5.
     examples = [doctest.Example(source='print(2)\n', want='1\n', lineno=4)]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples, name='t', filename='/tmp/fake.py'
     )
     result = dtest.run(verbose=0, on_error='return')
@@ -69,7 +70,7 @@ def test_multiple_examples_preserve_lineno_spacing():
         doctest.Example(source='x = 1\n', want='', lineno=10),
         doctest.Example(source='print(x)\n', want='1\n', lineno=20),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     assert dtest.lineno == 11
     # Force a parse to populate _parts so we can inspect line offsets.
     dtest._parse()
@@ -88,19 +89,19 @@ def test_empty_want_rejects_unexpected_stdout():
             lineno=0,
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['failed']
 
 
 def test_empty_want_uses_stdlib_displayhook_semantics():
-    silent = stdlib_compat.from_examples(
+    silent = stdlib_doctest.from_examples(
         [doctest.Example(source='None\n', want='', lineno=0)],
         name='silent',
     )
     assert silent.run(verbose=0, on_error='return')['passed']
 
-    displayed = stdlib_compat.from_examples(
+    displayed = stdlib_doctest.from_examples(
         [doctest.Example(source='1\n', want='', lineno=0)],
         name='displayed',
     )
@@ -112,7 +113,7 @@ def test_empty_want_output_cannot_satisfy_later_example():
         doctest.Example(source='print("a")\n', want='', lineno=0),
         doctest.Example(source='pass\n', want='a\n', lineno=1),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['failed']
 
@@ -127,7 +128,7 @@ def test_skip_option_is_honored():
         ),
         doctest.Example(source='print(2)\n', want='2\n', lineno=2),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='raise')
     assert result['passed']
 
@@ -144,7 +145,7 @@ def test_per_example_skip_preserves_execution_boundary():
         ),
         doctest.Example(source='print(x)\n', want='1\n', lineno=2),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed'], result
     assert not result['failed']
@@ -169,7 +170,7 @@ def test_skip_option_does_not_rewrite_source():
             options={doctest.SKIP: True},
         ),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     assert dtest.docsrc is not None
     assert 'xdoctest' not in dtest.docsrc
     assert 'SKIP' not in dtest.docsrc
@@ -202,7 +203,7 @@ def test_per_example_option_applies_to_matching_part_only():
         ),
         doctest.Example(source='print(2)\n', want='2\n', lineno=2),
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         name='t',
         config={'output_checker': 'part_local_recorder'},
@@ -229,7 +230,7 @@ def test_registered_checker_only_flag_flows_through():
     xdoctest.register_checker('intake_recorder', Recorder)
 
     examples = [doctest.Example(source='print(1)\n', want='1\n', lineno=0)]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         name='t',
         optionflags=fix_flag,
@@ -251,7 +252,7 @@ def test_stdlib_doctest_roundtrip_runs():
         lineno=10,
         docstring='',
     )
-    dtest = stdlib_compat.from_stdlib_doctest(stdlib_test)
+    dtest = stdlib_doctest.from_stdlib_doctest(stdlib_test)
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed']
     # Both stdlib values are zero-based; xdoctest stores one-based locations.
@@ -288,7 +289,7 @@ def test_stdlib_doctest_finder_preserves_physical_failure_line(tmp_path):
         '>>>'
     )
 
-    dtest = stdlib_compat.from_stdlib_doctest(stdlib_test)
+    dtest = stdlib_doctest.from_stdlib_doctest(stdlib_test)
     result = dtest.run(verbose=0, on_error='return')
     assert result['failed']
     assert dtest.lineno == physical_line
@@ -303,7 +304,7 @@ def test_builtin_optionflag_translates_to_runtime_state():
             lineno=0,
         )
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples, name='t', optionflags=doctest.ELLIPSIS
     )
     result = dtest.run(verbose=0, on_error='return')
@@ -311,7 +312,7 @@ def test_builtin_optionflag_translates_to_runtime_state():
 
 
 def test_zero_optionflags_disable_stdlib_comparison_flags():
-    ellipsis = stdlib_compat.from_examples(
+    ellipsis = stdlib_doctest.from_examples(
         [
             doctest.Example(
                 source='print("abc")\n',
@@ -325,7 +326,7 @@ def test_zero_optionflags_disable_stdlib_comparison_flags():
     assert ellipsis.config['reportchoice'] == 'none'
     assert ellipsis.run(verbose=0, on_error='return')['failed']
 
-    whitespace = stdlib_compat.from_examples(
+    whitespace = stdlib_doctest.from_examples(
         [
             doctest.Example(
                 source='print("a  b")\n',
@@ -341,7 +342,7 @@ def test_zero_optionflags_disable_stdlib_comparison_flags():
 
 def test_optionflags_preserve_unrelated_runtime_config():
     examples = [doctest.Example(source='print("ok")\n', want='ok\n', lineno=0)]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         optionflags=doctest.ELLIPSIS,
         config={
@@ -366,7 +367,7 @@ def test_whole_test_skip_optionflag_prevents_execution():
             lineno=0,
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, optionflags=doctest.SKIP)
+    dtest = stdlib_doctest.from_examples(examples, optionflags=doctest.SKIP)
     result = dtest.run(verbose=0, on_error='return')
     assert result['skipped']
     assert not result['failed']
@@ -376,7 +377,7 @@ def test_zero_optionflags_clear_configured_skip():
     examples = [
         doctest.Example(source='print("ran")\n', want='ran\n', lineno=0)
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         optionflags=0,
         config={'default_runtime_state': {'SKIP': True}},
@@ -410,7 +411,7 @@ def test_per_example_report_flags_are_local():
             lineno=1,
         ),
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         optionflags=doctest.REPORT_UDIFF,
         config={'output_checker': 'report_scope_recorder'},
@@ -447,7 +448,7 @@ def test_per_example_negative_report_flag_is_local():
             lineno=1,
         ),
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         optionflags=doctest.REPORT_NDIFF,
         config={'output_checker': 'negative_report_scope_recorder'},
@@ -461,7 +462,7 @@ def test_per_example_negative_report_flag_is_local():
 def test_none_optionflags_preserve_configured_checker_flags():
     custom = xdoctest.register_optionflag('CONFIGURED_INTAKE_FLAG')
     examples = [doctest.Example(source='print("ok")\n', want='ok\n', lineno=0)]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         optionflags=None,
         config={'output_checker_flags': custom},
@@ -470,8 +471,8 @@ def test_none_optionflags_preserve_configured_checker_flags():
 
 
 def test_warning_flags_are_top_level_exports():
-    assert xdoctest.IGNORE_WARNINGS is directive_facade.IGNORE_WARNINGS
-    assert xdoctest.SHOW_WARNINGS is directive_facade.SHOW_WARNINGS
+    assert xdoctest.IGNORE_WARNINGS is _optionflags.IGNORE_WARNINGS
+    assert xdoctest.SHOW_WARNINGS is _optionflags.SHOW_WARNINGS
 
 
 
@@ -495,7 +496,7 @@ def test_local_builtin_option_overrides_global_for_foreign_checker():
             options={doctest.ELLIPSIS: False},
         )
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         name='t',
         optionflags=doctest.ELLIPSIS,
@@ -528,7 +529,7 @@ def test_local_custom_option_can_mask_global_checker_flag():
             options={custom: False},
         )
     ]
-    dtest = stdlib_compat.from_examples(
+    dtest = stdlib_doctest.from_examples(
         examples,
         name='t',
         optionflags=custom,

--- a/tests/test_stdlib_doctest_warnings.py
+++ b/tests/test_stdlib_doctest_warnings.py
@@ -9,7 +9,7 @@ import doctest
 import pytest
 
 import xdoctest
-from xdoctest import stdlib_compat
+from xdoctest import stdlib_doctest
 
 
 def _register_warning_flags():
@@ -40,7 +40,7 @@ def test_warning_policy_does_not_rewrite_source():
             options={ignore_flag: True},
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     assert dtest.docsrc is not None
     assert user_source.strip() in dtest.docsrc
     # Source should not contain the doctestplus wrapper class.
@@ -59,7 +59,7 @@ def test_ignore_warnings_silences_warning():
             options={ignore_flag: True},
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     import warnings as _warnings
 
     with _warnings.catch_warnings(record=True) as record:
@@ -82,7 +82,7 @@ def test_show_warnings_captures_via_stdout():
             options={show_flag: True},
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed'], result
 
@@ -102,7 +102,7 @@ def test_failure_inside_warning_context_points_at_user_code_line():
             options={ignore_flag: True},
         )
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['failed']
     assert dtest.lineno == 8
@@ -116,7 +116,7 @@ def test_no_warning_policy_uses_default_no_op_context():
     examples = [
         doctest.Example(source='print(1)\n', want='1\n', lineno=0),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     # Without an active runstate (or warning flags) _part_context is a no-op.
     from contextlib import nullcontext
 
@@ -147,7 +147,7 @@ def test_warning_policy_is_per_part():
             options={},
         ),
     ]
-    dtest = stdlib_compat.from_examples(examples, name='t')
+    dtest = stdlib_doctest.from_examples(examples, name='t')
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed'], result
     # The runner records warnings that escape the parts in dtest.warn_list.


### PR DESCRIPTION
## What changed

- Replaces the broad `xdoctest.interop` module with the specifically named `xdoctest.stdlib_doctest` adapter package.
- Groups all existing stdlib-doctest support under that package:
  - `stdlib_doctest/__init__.py` is the documented public namespace and executable quick start.
  - `stdlib_doctest/_checker.py` contains checker registration, resolution, and the stdlib-shaped `OutputChecker`.
  - `stdlib_doctest/_optionflags.py` contains stdlib optionflag registration and runtime-state translation.
  - `stdlib_doctest/_convert.py` contains `doctest.Example` / `doctest.DocTest` intake.
- Removes the old top-level implementation modules `checker_facade.py`, `directive_facade.py`, `stdlib_compat.py`, and `interop.py` rather than leaving forwarding wrappers.
- Keeps the currently published top-level `xdoctest` aliases for now, but sources them from the single package.
- Updates core call sites to name their current private dependencies on `_checker` and `_optionflags` explicitly. This is intentionally an organizational move, not yet a redesign of which dependencies belong in core.
- Renames the dedicated tests and checked-in Sphinx page to match `stdlib_doctest`.

## Public package

```python
import xdoctest.stdlib_doctest as stdlib_doctest
```

The package re-exports the existing stdlib-shaped checker, optionflag, runtime-state conversion, and object-intake APIs. Its `__init__.py` contains documentation, the executable quick start, re-exports, and `__all__`; implementation remains in private modules.

## Validation

- 122 checker, directive, runner, intake, and warning tests passed; 2 environment-dependent tests skipped.
- All 19 doctests in `xdoctest.stdlib_doctest` passed, including the package quick start.
- Python 3.8 grammar and compilation checks passed.
- `mypy src/xdoctest` and `ty check src/xdoctest tests/` passed before packaging.
- Fatal flake8 selectors and `git diff --check` passed before packaging.
- The checked-in Sphinx API page rendered offline with no new package or duplicate-object diagnostics before packaging.
