### PR TITLE
Preserve stdlib example execution boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added the `deferred_output_matching` config knob and CLI flags to opt into
   stdlib/doctest-like output grouping without changing the default xdoctest
   behavior.
+* Added doctestplus compatibility for `FLOAT_CMP`, `IGNORE_OUTPUT`,
+  `__doctest_skip__`, and `__doctest_requires__`.
+* Added `IGNORE_WARNINGS` and `SHOW_WARNINGS` runtime directives. Warning
+  policy is applied at the runner level so failure line numbers continue to
+  point at user code.
+* Added `xdoctest.interop`, the documented integration contract for third-party
+  doctest tooling (`register_optionflag`, `register_checker`, `from_examples`,
+  and `from_stdlib_doctest`).
 
 ### Fixed
 * Fixed issue #181 where comment indentation could cause parsing issues.

--- a/src/xdoctest/__init__.py
+++ b/src/xdoctest/__init__.py
@@ -332,29 +332,12 @@ from xdoctest.runner import (
     doctest_callable,
     doctest_module,
 )
-from xdoctest.directive_facade import (
-    BLANKLINE_MARKER,
-    DONT_ACCEPT_BLANKLINE,
-    ELLIPSIS,
-    ELLIPSIS_MARKER,
-    FLOAT_CMP,
-    IGNORE_EXCEPTION_DETAIL,
-    IGNORE_OUTPUT,
-    IGNORE_WHITESPACE,
-    IGNORE_WANT,
-    NORMALIZE_REPR,
-    NORMALIZE_WHITESPACE,
-    REPORT_CDIFF,
-    REPORT_NDIFF,
-    REPORT_UDIFF,
-    optionflags_to_runtime_state,
-    register_optionflag,
-    runtime_state_to_optionflags,
-)
-from xdoctest.checker_facade import (
+# The full third-party integration contract lives in xdoctest.interop; the
+# two registration entry points are convenient enough to expose here.
+from xdoctest.interop import (
     OutputChecker,
     register_checker,
-    resolve_checker,
+    register_optionflag,
 )
 
 __all__ = [
@@ -367,24 +350,7 @@ __all__ = [
     'utils',
     'docstr',
     '__version__',
-    'BLANKLINE_MARKER',
-    'ELLIPSIS_MARKER',
-    'DONT_ACCEPT_BLANKLINE',
-    'NORMALIZE_WHITESPACE',
-    'ELLIPSIS',
-    'IGNORE_EXCEPTION_DETAIL',
-    'REPORT_UDIFF',
-    'REPORT_CDIFF',
-    'REPORT_NDIFF',
-    'IGNORE_WANT',
-    'IGNORE_OUTPUT',
-    'IGNORE_WHITESPACE',
-    'FLOAT_CMP',
-    'NORMALIZE_REPR',
     'register_optionflag',
-    'runtime_state_to_optionflags',
-    'optionflags_to_runtime_state',
     'register_checker',
-    'resolve_checker',
     'OutputChecker',
 ]

--- a/src/xdoctest/checker.py
+++ b/src/xdoctest/checker.py
@@ -272,6 +272,19 @@ def _xdoctest_check_output(
     return False
 
 
+def _selected_checker_name(
+    runstate: directive.RuntimeState | typing.Mapping | None,
+) -> str:
+    """
+    Return the name of the output checker selected by the runtime state.
+    """
+    if isinstance(runstate, directive.RuntimeState):
+        return runstate.get_output_checker()
+    if isinstance(runstate, typing.Mapping):
+        return str(runstate.get('_output_checker', 'xdoctest'))
+    return 'xdoctest'
+
+
 def check_output(
     got: str,
     want: str,
@@ -279,6 +292,12 @@ def check_output(
 ) -> bool:
     """
     Check output using the currently configured output checker backend.
+
+    The default ``'xdoctest'`` checker consumes the structured runtime state
+    directly. Only when a foreign (registered) checker is selected are the
+    runtime state and checker-only bits packed into a stdlib-shaped
+    optionflags ``int`` — conversion happens at the boundary, not on the
+    native path.
 
     Args:
         got (str): text produced by the test
@@ -292,9 +311,12 @@ def check_output(
         return True
     if runstate is None:
         runstate = directive.RuntimeState()
+    checker_name = _selected_checker_name(runstate)
+    if checker_name == 'xdoctest':
+        return _xdoctest_check_output(got, want, runstate)
     from xdoctest import checker_facade
     optionflags = checker_facade.runtime_state_to_optionflags(runstate)
-    output_checker = checker_facade.resolve_current_checker(runstate)
+    output_checker = checker_facade.resolve_checker(checker_name)
     return bool(output_checker.check_output(want, got, optionflags))
 
 
@@ -854,15 +876,24 @@ class GotWantException(AssertionError):
         if runstate is None:
             runstate = directive.RuntimeState()
 
-        from xdoctest import checker_facade
-        output_checker = checker_facade.resolve_current_checker(runstate)
-        if (
-            output_checker.__class__.output_difference
-            is not checker_facade.OutputChecker.output_difference
-        ):
-            example = doctest.Example(source='', want=self.want)
-            optionflags = checker_facade.runtime_state_to_optionflags(runstate)
-            return output_checker.output_difference(example, self.got, optionflags)
+        checker_name = _selected_checker_name(runstate)
+        if checker_name != 'xdoctest':
+            # A foreign checker may provide its own difference rendering
+            # (e.g. to display fixed-up wants); fall back to the native
+            # renderer when it inherits the facade default.
+            from xdoctest import checker_facade
+            output_checker = checker_facade.resolve_checker(checker_name)
+            if (
+                output_checker.__class__.output_difference
+                is not checker_facade.OutputChecker.output_difference
+            ):
+                example = doctest.Example(source='', want=self.want)
+                optionflags = checker_facade.runtime_state_to_optionflags(
+                    runstate
+                )
+                return output_checker.output_difference(
+                    example, self.got, optionflags
+                )
 
         return self._output_difference_xdoctest(
             runstate=runstate,

--- a/src/xdoctest/checker_facade.py
+++ b/src/xdoctest/checker_facade.py
@@ -21,7 +21,6 @@ Adopters typically:
 from __future__ import annotations
 
 import doctest
-import types
 from typing import Any, Mapping, Union
 
 from xdoctest import checker, directive
@@ -38,6 +37,7 @@ instantiated lazily by :func:`resolve_checker`.
 """
 
 _REGISTERED_CHECKERS: dict[str, CheckerLike] = {}
+_RESOLVED_INSTANCES: dict[str, doctest.OutputChecker] = {}
 
 
 def register_checker(name: str, checker_: CheckerLike) -> None:
@@ -48,16 +48,20 @@ def register_checker(name: str, checker_: CheckerLike) -> None:
     Args:
         name (str): selection key used in configs and runtime state.
         checker_: either an :class:`doctest.OutputChecker` instance or a class
-            with a no-argument constructor that returns one.
+            with a no-argument constructor that returns one. Register an
+            instance when the checker needs configuration (e.g. tolerances).
     """
     _REGISTERED_CHECKERS[name] = checker_
+    _RESOLVED_INSTANCES.pop(name, None)
 
 
 def resolve_checker(name: str) -> doctest.OutputChecker:
     """
     Return an :class:`doctest.OutputChecker` instance for a registered name.
 
-    Classes are instantiated each time. Instances are returned as-is.
+    Registered instances are returned as-is. Registered classes are
+    instantiated once and cached (re-registering a name invalidates the
+    cache), so checks do not pay per-call construction.
 
     Raises:
         KeyError: if the name has not been registered.
@@ -71,7 +75,11 @@ def resolve_checker(name: str) -> doctest.OutputChecker:
     checker_ = _REGISTERED_CHECKERS[name]
     if isinstance(checker_, doctest.OutputChecker):
         return checker_
-    return checker_()
+    instance = _RESOLVED_INSTANCES.get(name)
+    if instance is None:
+        instance = checker_()
+        _RESOLVED_INSTANCES[name] = instance
+    return instance
 
 
 def resolve_current_checker(

--- a/src/xdoctest/checker_facade.py
+++ b/src/xdoctest/checker_facade.py
@@ -1,8 +1,28 @@
+"""
+Stdlib-doctest-shaped façade over xdoctest's checker.
+
+This module exposes a small public surface that lets tooling built around the
+stdlib :mod:`doctest` module (most notably :mod:`pytest_doctestplus`) plug
+into xdoctest's runner without having to know about xdoctest's internal
+:class:`~xdoctest.directive.RuntimeState`.
+
+Adopters typically:
+
+1. Register their optionflags through :func:`xdoctest.register_optionflag`
+   (re-exported here from :mod:`xdoctest.directive_facade`).
+2. Define an :class:`OutputChecker` subclass with the standard
+   ``check_output(want, got, optionflags)`` and (optionally)
+   ``output_difference(example, got, optionflags)`` signatures.
+3. Register the checker by name with :func:`register_checker`.
+4. Select the checker for a given doctest by setting
+   ``DoctestConfig['output_checker']`` to that name.
+"""
+
 from __future__ import annotations
 
 import doctest
 import types
-import typing
+from typing import Any, Mapping, Union
 
 from xdoctest import checker, directive
 from xdoctest.directive_facade import (
@@ -11,20 +31,37 @@ from xdoctest.directive_facade import (
     runtime_state_to_optionflags,
 )
 
-_REGISTERED_CHECKERS: dict[
-    str, doctest.OutputChecker | type[doctest.OutputChecker]
-] = {}
+CheckerLike = Union[doctest.OutputChecker, type]
+"""
+A registered checker may be either an instance or a class. Classes are
+instantiated lazily by :func:`resolve_checker`.
+"""
+
+_REGISTERED_CHECKERS: dict[str, CheckerLike] = {}
 
 
-def register_checker(
-    name: str,
-    checker_: doctest.OutputChecker | type[doctest.OutputChecker],
-) -> None:
+def register_checker(name: str, checker_: CheckerLike) -> None:
+    """
+    Register an output checker under a name so it can be selected by setting
+    ``DoctestConfig['output_checker']`` to that name.
+
+    Args:
+        name (str): selection key used in configs and runtime state.
+        checker_: either an :class:`doctest.OutputChecker` instance or a class
+            with a no-argument constructor that returns one.
+    """
     _REGISTERED_CHECKERS[name] = checker_
 
 
-
 def resolve_checker(name: str) -> doctest.OutputChecker:
+    """
+    Return an :class:`doctest.OutputChecker` instance for a registered name.
+
+    Classes are instantiated each time. Instances are returned as-is.
+
+    Raises:
+        KeyError: if the name has not been registered.
+    """
     if name not in _REGISTERED_CHECKERS:
         raise KeyError(
             'Unknown output checker {!r}. Known checkers are {}'.format(
@@ -37,13 +74,19 @@ def resolve_checker(name: str) -> doctest.OutputChecker:
     return checker_()
 
 
-
 def resolve_current_checker(
-    runstate: directive.RuntimeState | dict | None,
+    runstate: directive.RuntimeState | Mapping[str, Any] | None,
 ) -> doctest.OutputChecker:
+    """
+    Return the checker selected by the given runtime state.
+
+    Accepts a :class:`~xdoctest.directive.RuntimeState`, a plain mapping
+    (the ``_output_checker`` key is consulted), or ``None``. In all cases a
+    valid checker is returned, defaulting to ``'xdoctest'``.
+    """
     if isinstance(runstate, directive.RuntimeState):
         checker_name = runstate.get_output_checker()
-    elif isinstance(runstate, dict):
+    elif isinstance(runstate, Mapping):
         checker_name = str(runstate.get('_output_checker', 'xdoctest'))
     else:
         checker_name = 'xdoctest'
@@ -51,6 +94,19 @@ def resolve_current_checker(
 
 
 class OutputChecker(doctest.OutputChecker):
+    """
+    Default xdoctest checker exposed through a stdlib-doctest interface.
+
+    Subclasses can wrap or extend xdoctest's matching by calling
+    ``super().check_output(want, got, optionflags)`` to delegate the base
+    comparison while adding their own pre-/post-processing.
+
+    Note:
+        This class intentionally accepts the same ``(want, got, optionflags)``
+        signature as :class:`doctest.OutputChecker` so that it is a drop-in
+        replacement for stdlib-shaped consumers.
+    """
+
     def check_output(
         self, want: str, got: str, optionflags: int
     ) -> bool:
@@ -59,7 +115,7 @@ class OutputChecker(doctest.OutputChecker):
 
     def output_difference(
         self,
-        example: typing.Any,
+        example: Any,
         got: str,
         optionflags: int,
     ) -> str:

--- a/src/xdoctest/directive.py
+++ b/src/xdoctest/directive.py
@@ -33,6 +33,10 @@ The basic directives and their defaults are as follows:
 
     * ``FLOAT_CMP``: False,
 
+    * ``IGNORE_WARNINGS``: False,
+
+    * ``SHOW_WARNINGS``: False,
+
     * ``NORMALIZE_REPR``: True,
 
     * ``REPORT_CDIFF``: False,
@@ -224,6 +228,8 @@ class RuntimeStateDict(TypedDict, total=False):
     IGNORE_OUTPUT: bool
     FLOAT_CMP: bool
     REQUIRE_WANT: bool
+    IGNORE_WARNINGS: bool
+    SHOW_WARNINGS: bool
     NORMALIZE_REPR: bool
     REPORT_CDIFF: bool
     REPORT_NDIFF: bool
@@ -249,6 +255,12 @@ DEFAULT_RUNTIME_STATE: RuntimeStateDict = {
     # When enabled, output-producing parts must have an explicit local want.
     # Silent setup parts remain valid without a want.
     'REQUIRE_WANT': False,
+    # Runner-level warning policy. IGNORE_WARNINGS silences warnings emitted
+    # while a part executes; SHOW_WARNINGS captures them and prints
+    # "Category: message" lines into the part's output so they participate in
+    # got/want matching. IGNORE_WARNINGS takes precedence when both are set.
+    'IGNORE_WARNINGS': False,
+    'SHOW_WARNINGS': False,
     # 'IGNORE_MEASUREMENTS': False,
     # TODO: I want this flag to turn on normalization of numbers,
     # I.E: non-determenistic measurements do not cause doctest failure, but
@@ -315,6 +327,7 @@ class RuntimeState(utils.NiceRepr):
             IGNORE_EXCEPTION_DETAIL: False,
             IGNORE_OUTPUT: False,
             IGNORE_WANT: False,
+            IGNORE_WARNINGS: False,
             IGNORE_WHITESPACE: False,
             NORMALIZE_REPR: True,
             NORMALIZE_WHITESPACE: True,
@@ -323,6 +336,7 @@ class RuntimeState(utils.NiceRepr):
             REPORT_UDIFF: True,
             REQUIRES: set(...),
             REQUIRE_WANT: False,
+            SHOW_WARNINGS: False,
             SKIP: False
         })>
     """

--- a/src/xdoctest/directive_facade.py
+++ b/src/xdoctest/directive_facade.py
@@ -1,3 +1,27 @@
+"""
+Bridge between stdlib :mod:`doctest`-style optionflags and xdoctest's
+structured :class:`~xdoctest.directive.RuntimeState`.
+
+Adopters use :func:`register_optionflag` to register a checker-only flag
+(returning a stable ``int`` bit, identical to what
+:func:`doctest.register_optionflag` returns) and may then enable it via
+xdoctest directives like ``# xdoctest: +MY_FLAG``. Inside the runner the bit
+is carried on :class:`~xdoctest.directive.RuntimeState` and ultimately
+delivered to the active output checker as the standard ``flags`` argument.
+
+The bridge is two-way:
+
+- :func:`runtime_state_to_optionflags` packs the structured runtime state
+  into a stdlib-shaped optionflags ``int``.
+- :func:`optionflags_to_runtime_state` unpacks an optionflags ``int`` back
+  into a :class:`RuntimeState`.
+
+Stdlib defaults (``ELLIPSIS``, ``NORMALIZE_WHITESPACE``, ...) are mapped to
+their corresponding xdoctest runtime keys at import time. Custom flags do
+not touch :class:`RuntimeState` keys; they are carried through as
+checker-only optionflag bits.
+"""
+
 from __future__ import annotations
 
 import doctest
@@ -18,11 +42,29 @@ REPORT_NDIFF = doctest.REPORT_NDIFF
 
 
 class RuntimeFlagFacade:
+    """
+    Registry mapping optionflag names <-> ``int`` bits, and (optionally)
+    optionflag bits <-> :class:`~xdoctest.directive.RuntimeState` keys.
+
+    Two kinds of registrations exist:
+
+    - Builtin flags (``ELLIPSIS``, ``NORMALIZE_WHITESPACE``, ...): these are
+      bidirectionally bound to a runtime state key so xdoctest's structured
+      state and stdlib-style ``flags`` round-trip cleanly.
+    - Plain registered flags (``FIX``, ``FLOAT_CMP``, ...): these have no
+      structured runtime state representation and are carried as
+      checker-only bits inside the runtime state.
+    """
+
     def __init__(self) -> None:
         self._optionflags_by_name: Dict[str, int] = {}
         self._optionflag_names_by_value: Dict[int, str] = {}
         self._runtime_key_to_optionflag: Dict[str, int] = {}
         self._optionflag_to_runtime_key: Dict[int, str] = {}
+
+    def _bind_runtime_key(self, name: str, flag: int, runtime_state_key: str) -> None:
+        self._runtime_key_to_optionflag[runtime_state_key] = flag
+        self._optionflag_to_runtime_key[flag] = runtime_state_key
 
     def register_builtin_optionflag(
         self,
@@ -30,11 +72,13 @@ class RuntimeFlagFacade:
         flag: int,
         runtime_state_key: str | None = None,
     ) -> int:
+        """
+        Bind a stdlib-doctest builtin flag to its runtime state key.
+        """
         self._optionflags_by_name[name] = flag
         self._optionflag_names_by_value[flag] = name
         if runtime_state_key is not None:
-            self._runtime_key_to_optionflag[runtime_state_key] = flag
-            self._optionflag_to_runtime_key[flag] = runtime_state_key
+            self._bind_runtime_key(name, flag, runtime_state_key)
         return flag
 
     def register_optionflag(
@@ -42,11 +86,18 @@ class RuntimeFlagFacade:
         name: str,
         runtime_state_key: str | None = None,
     ) -> int:
+        """
+        Register an optionflag name and return its ``int`` bit.
+
+        The returned ``int`` is exactly the value that
+        :func:`doctest.register_optionflag` would return for this name, so
+        third-party tooling that wires the same name through stdlib doctest
+        will see consistent bits.
+        """
         if name in self._optionflags_by_name:
             flag = self._optionflags_by_name[name]
             if runtime_state_key is not None:
-                self._runtime_key_to_optionflag[runtime_state_key] = flag
-                self._optionflag_to_runtime_key[flag] = runtime_state_key
+                self._bind_runtime_key(name, flag, runtime_state_key)
             return flag
         flag = doctest.register_optionflag(name)
         return self.register_builtin_optionflag(name, flag, runtime_state_key)
@@ -64,6 +115,16 @@ class RuntimeFlagFacade:
         self,
         runstate: directive.RuntimeState | dict | None,
     ) -> int:
+        """
+        Pack a :class:`~xdoctest.directive.RuntimeState` (or a plain mapping)
+        into a stdlib-shaped optionflags ``int``.
+
+        Includes:
+
+        - Any checker-only flags carried via
+          :meth:`RuntimeState.get_output_checker_flags`
+        - Any builtin flags whose mapped runtime key is currently ``True``
+        """
         flags = 0
         if isinstance(runstate, directive.RuntimeState):
             flags |= runstate.get_output_checker_flags()
@@ -91,6 +152,14 @@ class RuntimeFlagFacade:
         optionflags: int,
         default_state: directive.RuntimeStateDict | None = None,
     ) -> directive.RuntimeState:
+        """
+        Unpack an optionflags ``int`` into a fresh
+        :class:`~xdoctest.directive.RuntimeState`.
+
+        Builtin flag bits are reflected onto the structured runtime state.
+        Any unregistered bits are preserved verbatim as checker-only
+        optionflags so they can be delivered to a custom checker.
+        """
         base_state = {} if default_state is None else dict(default_state)
         for runtime_key in self._runtime_key_to_optionflag:
             if runtime_key == 'REQUIRES':
@@ -111,6 +180,10 @@ _RUNTIME_FLAGS = RuntimeFlagFacade()
 
 
 def register_optionflag(name: str, runtime_state_key: str | None = None) -> int:
+    """
+    Register an optionflag with xdoctest. See
+    :meth:`RuntimeFlagFacade.register_optionflag`.
+    """
     return _RUNTIME_FLAGS.register_optionflag(name, runtime_state_key)
 
 
@@ -159,6 +232,8 @@ IGNORE_OUTPUT = register_optionflag('IGNORE_OUTPUT', 'IGNORE_OUTPUT')
 IGNORE_WHITESPACE = register_optionflag('IGNORE_WHITESPACE', 'IGNORE_WHITESPACE')
 FLOAT_CMP = register_optionflag('FLOAT_CMP', 'FLOAT_CMP')
 NORMALIZE_REPR = register_optionflag('NORMALIZE_REPR', 'NORMALIZE_REPR')
+IGNORE_WARNINGS = register_optionflag('IGNORE_WARNINGS', 'IGNORE_WARNINGS')
+SHOW_WARNINGS = register_optionflag('SHOW_WARNINGS', 'SHOW_WARNINGS')
 
 
 __all__ = [
@@ -176,6 +251,8 @@ __all__ = [
     'IGNORE_WHITESPACE',
     'FLOAT_CMP',
     'NORMALIZE_REPR',
+    'IGNORE_WARNINGS',
+    'SHOW_WARNINGS',
     'register_optionflag',
     'runtime_state_to_optionflags',
     'optionflags_to_runtime_state',

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import __future__
 
 import ast
+import contextlib
 import math
 import os
 import re
@@ -319,6 +320,35 @@ class DoctestConfig(dict):
             return self[key]
         else:
             return given
+
+
+@contextlib.contextmanager
+def _ignore_warnings_context():
+    """
+    Silence warnings emitted while the body runs (the ``IGNORE_WARNINGS``
+    runtime directive).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        yield
+
+
+@contextlib.contextmanager
+def _show_warnings_context():
+    """
+    Capture warnings emitted while the body runs and print them afterwards
+    as ``Category: message`` lines (the ``SHOW_WARNINGS`` runtime
+    directive). The prints land in the part's captured stdout, so shown
+    warnings participate in got/want matching.
+    """
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter('always')
+        yield
+    for warn in captured:
+        category_name = getattr(
+            warn, '_category_name', warn.category.__name__
+        )
+        print(f'{category_name}: {warn.message}')
 
 
 def _doctest_requirement_satisfied(requirement_text: str) -> bool:
@@ -883,6 +913,30 @@ class DocTest:
         for partno, part in enumerate(self._parts):
             part.partno = partno
 
+    def _part_context(self, part, partx):
+        """
+        Return a context manager that wraps the execution of one doctest
+        part, applying the runtime warning policy.
+
+        When ``IGNORE_WARNINGS`` is active for the part, warnings emitted
+        during execution are silenced. When ``SHOW_WARNINGS`` is active,
+        warnings are captured and printed as ``Category: message`` lines
+        into the part's output so they participate in got/want matching.
+        Both are applied at the runner level — the part's source is never
+        rewritten, so failure line numbers always point at user code.
+
+        Args:
+            part: the :class:`xdoctest.doctest_part.DoctestPart` about to run.
+            partx (int): the part's index within ``self._parts``.
+        """
+        runstate = self._runstate
+        if runstate is not None:
+            if runstate['IGNORE_WARNINGS']:
+                return _ignore_warnings_context()
+            if runstate['SHOW_WARNINGS']:
+                return _show_warnings_context()
+        return contextlib.nullcontext()
+
     def _import_module(self) -> None:
         """
         After this point we are in dynamic analysis mode, in most cases
@@ -1358,12 +1412,15 @@ class DocTest:
                                 asyncio_runner.close()
                             finally:
                                 asyncio_runner = None
-                        # Execute the doctest code
+                        # Execute the doctest code. ``_part_context`` is an
+                        # extension point used by the stdlib_compat intake
+                        # seam to apply per-part warning policy without
+                        # rewriting source. Default is a no-op.
                         try:
                             # NOTE: For code passed to eval or exec, there is no
                             # difference between locals and globals. Only pass in
                             # one dict, otherwise there is weird behavior
-                            with cap:
+                            with cap, self._part_context(part, partx):
                                 # We can execute each part using exec or eval.  If
                                 # a doctest part has `compile_mode=eval` we
                                 # expect it to return an object with a repr that

--- a/src/xdoctest/doctest_example.py
+++ b/src/xdoctest/doctest_example.py
@@ -7,6 +7,7 @@ import __future__
 
 import ast
 import contextlib
+import functools
 import math
 import os
 import re
@@ -351,9 +352,34 @@ def _show_warnings_context():
         print(f'{category_name}: {warn.message}')
 
 
+# Matches a bare distribution/module name (no version specifier), which can
+# be evaluated without the optional ``packaging`` dependency.
+_BARE_REQUIREMENT_RE = re.compile(r'^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$')
+
+
+def _distribution_or_module_exists(name: str) -> bool:
+    try:
+        importlib_metadata_compat.version(name)
+    except Exception:
+        pass
+    else:
+        return True
+    from importlib.util import find_spec
+
+    try:
+        return find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
 def _doctest_requirement_satisfied(requirement_text: str) -> bool:
     """
     Return True when a doctestplus-style requirement is satisfied.
+
+    Bare names are checked against installed distributions and importable
+    modules and do not need ``packaging``. Requirements with version
+    specifiers need the optional ``packaging`` dependency; without it they
+    are treated as unsatisfied (skip) with a warning rather than erroring.
 
     Example:
         >>> from xdoctest.doctest_example import _doctest_requirement_satisfied
@@ -377,9 +403,15 @@ def _doctest_requirement_satisfied(requirement_text: str) -> bool:
         ValueError: Invalid __doctest_requires__ requirement: 'bad requirement'
     """
     if Requirement is None:
-        raise ImportError(
-            'packaging is required to evaluate __doctest_requires__'
+        text = requirement_text.strip()
+        if _BARE_REQUIREMENT_RE.match(text):
+            return _distribution_or_module_exists(text)
+        warnings.warn(
+            'packaging is required to evaluate the constrained '
+            '__doctest_requires__ requirement {!r}; treating it as '
+            'unsatisfied'.format(requirement_text)
         )
+        return False
 
     try:
         requirement = Requirement(requirement_text)
@@ -398,13 +430,35 @@ def _doctest_requirement_satisfied(requirement_text: str) -> bool:
     if not requirement.specifier:
         if installed_version is not None:
             return True
-        from importlib.util import find_spec
-
-        return find_spec(requirement.name) is not None
+        return _distribution_or_module_exists(requirement.name)
 
     if installed_version is None:
         return False
     return requirement.specifier.contains(installed_version, prereleases=True)
+
+
+@functools.lru_cache(maxsize=None)
+def _static_module_doctest_metadata(modpath: str):
+    """
+    Statically parse ``__doctest_skip__`` and ``__doctest_requires__`` from a
+    module file. Cached per path because a module commonly holds many
+    doctests and static parsing is comparatively expensive.
+
+    Returns:
+        Tuple[Any, Any]: ``(skip_spec, requires_spec)``
+    """
+    values = []
+    for key in ['__doctest_skip__', '__doctest_requires__']:
+        try:
+            value = static.parse_static_value(key, fpath=modpath)
+        except NameError:
+            value = None
+        except Exception as ex:
+            raise ValueError(
+                'Failed to read {!r} from {!r}: {}'.format(key, modpath, ex)
+            )
+        values.append(value)
+    return tuple(values)
 
 
 class DocTest:
@@ -613,6 +667,10 @@ class DocTest:
         self.logged_stdout = OrderedDict()
         self._unmatched_stdout = []
         self._skipped_parts = []
+
+        # Human-readable reason when module-level doctest metadata
+        # (__doctest_skip__ / __doctest_requires__) caused a skip.
+        self._metadata_skip_reason: str | None = None
 
         self._runstate = None
 
@@ -1090,32 +1148,24 @@ class DocTest:
             if isinstance(modpath, (str, os.PathLike)) and os.path.exists(
                 modpath
             ):
-                for key in ['__doctest_skip__', '__doctest_requires__']:
-                    try:
-                        value = static.parse_static_value(
-                            key, fpath=os.fspath(modpath)
-                        )
-                    except NameError:
-                        value = None
-                    except Exception as ex:
-                        raise ValueError(
-                            'Failed to read {!r} from {!r}: {}'.format(
-                                key, modpath, ex
-                            )
-                        )
-                    if key == '__doctest_skip__':
-                        skip_spec = value
-                    else:
-                        requires_spec = value
+                skip_spec, requires_spec = _static_module_doctest_metadata(
+                    os.fspath(modpath)
+                )
 
         if skip_spec is not None and self._matches_doctest_skip(skip_spec):
             runstate['SKIP'] = True
+            self._metadata_skip_reason = 'listed in `__doctest_skip__`'
             return
 
-        if requires_spec is not None and not self._module_requires_satisfied(
-            requires_spec
-        ):
-            runstate['SKIP'] = True
+        if requires_spec is not None:
+            unmet = self._unmet_module_requirement(requires_spec)
+            if unmet is not None:
+                runstate['SKIP'] = True
+                self._metadata_skip_reason = (
+                    'unmet `__doctest_requires__` requirement: {!r}'.format(
+                        unmet
+                    )
+                )
 
     def _matches_doctest_skip(self, skip_spec: Any) -> bool:
         if isinstance(skip_spec, str):
@@ -1140,7 +1190,11 @@ class DocTest:
                 return True
         return False
 
-    def _module_requires_satisfied(self, requires_spec: Any) -> bool:
+    def _unmet_module_requirement(self, requires_spec: Any) -> str | None:
+        """
+        Return the first unmet ``__doctest_requires__`` requirement that
+        applies to this doctest, or ``None`` when everything is satisfied.
+        """
         if not isinstance(requires_spec, dict):
             raise ValueError(
                 '__doctest_requires__ must be a dictionary of patterns to requirements'
@@ -1176,9 +1230,9 @@ class DocTest:
                         '__doctest_requires__ requirements must be strings'
                     )
                 if not _doctest_requirement_satisfied(req_text):
-                    return False
+                    return req_text
 
-        return True
+        return None
 
     def run(
         self, verbose: int | None | bool = None, on_error: str | None = None
@@ -1213,6 +1267,7 @@ class DocTest:
 
         self._skipped_parts = []
         self.exc_info = None
+        self._metadata_skip_reason = None
         self._suppressed_stdout = verbose <= 1
 
         # Reset traceback bookkeeping from any prior run.
@@ -1655,7 +1710,10 @@ class DocTest:
             if self.mode == 'pytest':
                 import pytest
 
-                pytest.skip()
+                if self._metadata_skip_reason is not None:
+                    pytest.skip(self._metadata_skip_reason)
+                else:
+                    pytest.skip()
 
         summary = self._post_run(verbose)
 

--- a/src/xdoctest/interop.py
+++ b/src/xdoctest/interop.py
@@ -1,0 +1,71 @@
+"""
+Public interoperability surface for third-party doctest tooling.
+
+This module is the documented, stable contract for tools that integrate with
+xdoctest's runner — pytest plugins (e.g. :mod:`pytest_doctestplus`), sphinx
+extensions, or custom collectors that already speak the stdlib
+:mod:`doctest` vocabulary. The surface is intentionally small:
+
+Registration:
+
+- :func:`register_optionflag` — register a stdlib-style optionflag by name,
+  optionally bound to an xdoctest runtime-state key. Returns the same bit
+  that :func:`doctest.register_optionflag` would return for that name, so
+  flag bits stay consistent across both worlds. Registered flags can be
+  toggled with ``# xdoctest: +MY_FLAG`` directives and are delivered to the
+  active output checker via the standard ``flags`` argument.
+- :func:`register_checker` — register a stdlib-shaped output checker
+  (``check_output(want, got, flags)``) under a name. Select it per test via
+  ``DocTest.config['output_checker'] = name``. Register an *instance* when
+  the checker needs configuration (e.g. tolerances).
+
+Conversion:
+
+- :func:`from_examples` — build a runnable
+  :class:`xdoctest.doctest_example.DocTest` from stdlib-shaped example
+  objects (``source`` / ``want`` / ``lineno`` / ``options``). Line numbers
+  and source content are preserved; per-example options become structured
+  per-part directives.
+- :func:`from_stdlib_doctest` — the same, directly from a stdlib
+  :class:`doctest.DocTest`.
+
+Helpers:
+
+- :class:`OutputChecker` — xdoctest's native matcher behind the stdlib
+  checker interface; useful as a delegation base for custom checkers.
+- :func:`optionflags_to_runtime_state` / :func:`runtime_state_to_optionflags`
+  — convert between stdlib optionflag ints and xdoctest's structured
+  :class:`~xdoctest.directive.RuntimeState`.
+
+Relevant ``DocTest.config`` keys (both serializable):
+
+- ``output_checker`` (str): name of the registered checker to use.
+- ``output_checker_flags`` (int): persistent checker-only optionflag bits.
+
+The implementation modules (:mod:`xdoctest.directive_facade`,
+:mod:`xdoctest.checker_facade`, :mod:`xdoctest.stdlib_compat`) are internal;
+import from here instead.
+"""
+
+from xdoctest.checker_facade import (
+    OutputChecker,
+    register_checker,
+    resolve_checker,
+)
+from xdoctest.directive_facade import (
+    optionflags_to_runtime_state,
+    register_optionflag,
+    runtime_state_to_optionflags,
+)
+from xdoctest.stdlib_compat import from_examples, from_stdlib_doctest
+
+__all__ = [
+    'OutputChecker',
+    'from_examples',
+    'from_stdlib_doctest',
+    'optionflags_to_runtime_state',
+    'register_checker',
+    'register_optionflag',
+    'resolve_checker',
+    'runtime_state_to_optionflags',
+]

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -315,7 +315,11 @@ class XDoctestItem(pytest.Item):
         # verbose = self.dtest.config['verbose']
         self.dtest.run(on_error='raise')
         if not self.dtest.anything_ran():
-            pytest.skip('doctest is empty or all parts were skipped')
+            reason = (
+                getattr(self.dtest, '_metadata_skip_reason', None)
+                or 'doctest is empty or all parts were skipped'
+            )
+            pytest.skip(reason)
 
     def repr_failure(self, excinfo):  # type: ignore
         """

--- a/src/xdoctest/plugin.py
+++ b/src/xdoctest/plugin.py
@@ -201,8 +201,53 @@ def _pytest_collect_file(file_path, parent, **path_args):
             return XDoctestTextfile(file_path, parent)
 
 
+try:
+    from _pytest.fixtures import FixtureLookupError as _FixtureLookupError
+except ImportError:  # nocover
+    _FixtureLookupError = Exception  # type: ignore
+
+
+def _lookup_namespace_fixture(getfixturevalue) -> dict:
+    """
+    Resolve the ``xdoctest_namespace`` fixture defensively.
+
+    The fixture is defined by xdoctest's own pytest plugin. When an
+    :class:`XDoctestItem` is embedded by another plugin (e.g. the
+    pytest-doctestplus xdoctest backend) xdoctest's plugin may not be
+    registered, in which case the namespace is simply empty.
+    """
+    try:
+        return dict(getfixturevalue('xdoctest_namespace'))
+    except _FixtureLookupError:
+        return {}
+
+
+def _doctestplus_owns_textfiles(config) -> bool:
+    """
+    When pytest-doctestplus is enabled it owns ``.rst``/``.txt`` collection:
+    its parser implements the doctestplus RST directive language
+    (``.. doctest-skip::`` and friends), which xdoctest's plain textfile
+    collector does not understand. Collecting the same file from both
+    plugins would double-run or misparse it, so xdoctest defers.
+    """
+    if not config.pluginmanager.hasplugin('pytest_doctestplus'):
+        return False
+    try:
+        if config.getoption('doctest_plus', default=False):
+            return True
+    except Exception:
+        pass
+    try:
+        return bool(config.getini('doctest_plus'))
+    except Exception:
+        return False
+
+
 def _is_xdoctest(config, path, parent):
     matched = False
+    if _suffix(path) in ('.txt', '.rst'):
+        if _doctestplus_owns_textfiles(config):
+            return False
     if _suffix(path) in ('.txt', '.rst') and parent.session.isinitpath(path):
         matched = True
     else:
@@ -292,9 +337,10 @@ class XDoctestItem(pytest.Item):
         if _PYTEST_IS_GE_800:
             self._request._fillfixtures()
             globs = dict(getfixture=self._request.getfixturevalue)
-            for name, value in self._request.getfixturevalue(
-                'xdoctest_namespace'
-            ).items():
+            namespace = _lookup_namespace_fixture(
+                self._request.getfixturevalue
+            )
+            for name, value in namespace.items():
                 globs[name] = value
             self.dtest.globs.update(globs)
         else:
@@ -303,9 +349,10 @@ class XDoctestItem(pytest.Item):
                 global_namespace = dict(
                     getfixture=self.fixture_request.getfixturevalue  # type: ignore
                 )
-                for name, value in self.fixture_request.getfixturevalue(  # type: ignore
-                    'xdoctest_namespace'
-                ).items():
+                namespace = _lookup_namespace_fixture(
+                    self.fixture_request.getfixturevalue  # type: ignore
+                )
+                for name, value in namespace.items():
                     global_namespace[name] = value
                 self.dtest.global_namespace.update(global_namespace)
 

--- a/src/xdoctest/stdlib_compat.py
+++ b/src/xdoctest/stdlib_compat.py
@@ -30,17 +30,16 @@ Option semantics flow through one channel: each named stdlib optionflag in
 xdoctest runtime-state keys (``SKIP``, ``ELLIPSIS``, ``IGNORE_WARNINGS``,
 ...) modify the structured runtime state; any other *named* flag is adopted
 as a checker-only optionflag and delivered to the active output checker via
-the standard ``flags`` argument. Since consecutive want-less examples merge
-into a single xdoctest part, per-example options apply at part granularity.
+the standard ``flags`` argument. Each incoming stdlib example is parsed as
+its own execution boundary, so its options never leak to adjacent examples.
 """
 
 from __future__ import annotations
 
-import bisect
 import doctest as _doctest
 from typing import Any, Iterable, Mapping, Optional
 
-from xdoctest import directive, directive_facade
+from xdoctest import directive, directive_facade, parser
 from xdoctest.doctest_example import DocTest
 
 
@@ -90,7 +89,7 @@ def from_examples(
     if globs is None:
         globs = {'__name__': '__main__'}
 
-    base, docsrc, example_starts = _build_docsrc(examples)
+    base, docsrc = _build_docsrc(examples)
     if lineno is None:
         lineno = base if base is not None else 0
 
@@ -125,7 +124,7 @@ def from_examples(
         dtest.config['default_runtime_state'] = defaults
         dtest.config['output_checker_flags'] = int(optionflags)
 
-    _attach_option_directives(dtest, examples, example_starts)
+    _parse_examples_as_parts(dtest, examples, base)
     return dtest
 
 
@@ -167,82 +166,79 @@ def _build_docsrc(examples):
     examples, padding with blank lines so each example's prompt line in the
     reconstructed source mirrors its original ``Example.lineno`` offset.
 
-    Returns ``(base_lineno, docsrc, example_starts)`` where:
-
-    - ``base_lineno`` is the lineno of the first example (the offset that
-      should be passed to :class:`DocTest.lineno` so absolute file lines can
-      be recovered), or ``None`` if no examples were provided.
-    - ``docsrc`` is the reconstructed source.
-    - ``example_starts`` is a list of ``(docsrc_line, example_index)`` pairs
-      recording where each example's source begins in the rebuilt docsrc.
+    Returns ``(base_lineno, docsrc)`` where ``base_lineno`` is the lineno
+    of the first example (or ``None`` for an empty input), and ``docsrc``
+    is the reconstructed source.
     """
     if not examples:
-        return None, '', []
+        return None, ''
 
     base = examples[0].lineno
     lines: list[str] = []
-    example_starts: list[tuple[int, int]] = []
     cursor = 0
 
-    for idx, ex in enumerate(examples):
+    for ex in examples:
         target = (ex.lineno or 0) - base
         # Pad blank lines so the prompt aligns with the original lineno.
         while cursor < target:
             lines.append('')
             cursor += 1
 
-        example_starts.append((cursor, idx))
-        src_lines = (ex.source or '').splitlines() or ['']
-        for i, line in enumerate(src_lines):
-            prefix = '>>> ' if i == 0 else '... '
-            lines.append(prefix + line)
-            cursor += 1
+        example_lines = _example_docsrc_lines(ex)
+        lines.extend(example_lines)
+        cursor += len(example_lines)
 
-        if ex.want:
-            for w in ex.want.splitlines():
-                lines.append(w)
-                cursor += 1
-
-    return base, '\n'.join(lines), example_starts
+    return base, '\n'.join(lines)
 
 
-def _attach_option_directives(dtest, examples, example_starts):
+def _parse_examples_as_parts(dtest, examples, base):
+    """Parse each stdlib example independently and concatenate its parts.
+
+    A stdlib :class:`doctest.Example` is an execution and option-scope
+    boundary. Parsing the reconstructed full docsrc in one pass can merge
+    adjacent want-less examples into one xdoctest part, which broadens options
+    such as ``SKIP`` to statements that belong to a different example. Parse
+    each incoming example independently so its options apply only to the code
+    it owns, while retaining the reconstructed full docsrc for display.
     """
-    Translate per-example ``options`` dicts into structured per-part
-    directives on the parsed :class:`DocTest`.
-
-    xdoctest may merge consecutive want-less examples into one part, so each
-    part collects the options of every example whose source starts within
-    its line span (later examples win on conflicting flags).
-    """
-    if not example_starts:
-        return
-    if not any(getattr(examples[idx], 'options', None) for _, idx in example_starts):
+    if not examples:
         return
 
-    dtest._parse()
-    parts = dtest._parts or []
-    if not parts:
-        return
+    base = 0 if base is None else base
+    parts = []
+    for ex in examples:
+        local_docsrc = '\n'.join(_example_docsrc_lines(ex))
+        info = {
+            'callname': dtest.callname,
+            'modpath': dtest.modpath,
+            'lineno': dtest.lineno,
+            'fpath': dtest.fpath,
+        }
+        raw_parts = parser.DoctestParser().parse(local_docsrc, info)
+        local_parts = [part for part in raw_parts if not isinstance(part, str)]
+        line_offset = (ex.lineno or 0) - base
+        for part in local_parts:
+            part.line_offset += line_offset
+            extra = _options_to_directives(getattr(ex, 'options', None) or {})
+            if extra:
+                # Preserve directives written inline in the original source;
+                # structured stdlib options come after so they win on conflict.
+                part._directives = list(part.directives) + extra
+            parts.append(part)
+    dtest._parts = parts
 
-    part_offsets = [part.line_offset for part in parts]
-    examples_by_part: dict[int, list[int]] = {}
-    for start_line, ex_idx in example_starts:
-        partx = bisect.bisect_right(part_offsets, start_line) - 1
-        if partx < 0:
-            continue
-        examples_by_part.setdefault(partx, []).append(ex_idx)
 
-    for partx, ex_idxs in examples_by_part.items():
-        merged: dict = {}
-        for ex_idx in ex_idxs:
-            merged.update(getattr(examples[ex_idx], 'options', None) or {})
-        extra = _options_to_directives(merged)
-        if extra:
-            part = parts[partx]
-            # Preserve directives written inline in the original source;
-            # structured options come after so they win on conflict.
-            part._directives = list(part.directives) + extra
+def _example_docsrc_lines(ex):
+    """Reconstruct the prompted source and want lines for one example."""
+    lines = []
+    src_lines = (ex.source or '').splitlines() or ['']
+    for idx, line in enumerate(src_lines):
+        prefix = '>>> ' if idx == 0 else '... '
+        lines.append(prefix + line)
+    if ex.want:
+        lines.extend(ex.want.splitlines())
+    return lines
+
 
 
 def _options_to_directives(options):

--- a/src/xdoctest/stdlib_compat.py
+++ b/src/xdoctest/stdlib_compat.py
@@ -1,0 +1,283 @@
+"""
+Generic intake seam: convert stdlib-doctest-shaped objects into runnable
+:class:`xdoctest.doctest_example.DocTest` instances.
+
+This module is the third-party adapter surface for tools that already produce
+stdlib :class:`doctest.Example` lists (:mod:`pytest_doctestplus`, sphinx
+extensions, custom collectors) and want xdoctest's runner without writing
+their own runner adapter.
+
+The intake function :func:`from_examples` is intentionally generic — it does
+not import or know about any specific tool. It accepts any sequence of
+example-like objects with the standard ``source``, ``want``, ``lineno``,
+``options`` shape.
+
+Fidelity guarantees:
+
+- **Line numbers**: the reconstructed docsrc pads with blank lines so that
+  each example's prompt line matches its original ``lineno`` offset, and
+  ``DocTest.lineno`` is set to the first example's base line. xdoctest's
+  parser then assigns each part a ``line_offset`` such that
+  ``dtest.lineno + part.line_offset == original_file_line``.
+- **Source content**: example source is carried verbatim (only the standard
+  ``>>> `` / ``... `` prompts are re-added). Per-example semantics from
+  ``Example.options`` are attached to the parsed parts as *structured*
+  :class:`~xdoctest.directive.Directive` objects — never by injecting
+  directive comments into the source text.
+
+Option semantics flow through one channel: each named stdlib optionflag in
+``Example.options`` becomes a per-part directive. Flags whose names match
+xdoctest runtime-state keys (``SKIP``, ``ELLIPSIS``, ``IGNORE_WARNINGS``,
+...) modify the structured runtime state; any other *named* flag is adopted
+as a checker-only optionflag and delivered to the active output checker via
+the standard ``flags`` argument. Since consecutive want-less examples merge
+into a single xdoctest part, per-example options apply at part granularity.
+"""
+
+from __future__ import annotations
+
+import bisect
+import doctest as _doctest
+from typing import Any, Iterable, Mapping, Optional
+
+from xdoctest import directive, directive_facade
+from xdoctest.doctest_example import DocTest
+
+
+def from_examples(
+    examples: Iterable[Any],
+    *,
+    globs: Optional[Mapping[str, Any]] = None,
+    name: str = '<doctest>',
+    filename: Optional[str] = None,
+    lineno: Optional[int] = None,
+    optionflags: int = 0,
+    config: Optional[Mapping[str, Any]] = None,
+) -> DocTest:
+    """
+    Build a runnable xdoctest :class:`DocTest` from a sequence of stdlib-like
+    example objects.
+
+    Args:
+        examples: iterable of objects each with ``source``, ``want``,
+            ``lineno`` and (optionally) ``options`` attributes — i.e. the
+            stdlib :class:`doctest.Example` shape.
+        globs: namespace dict for the doctest. Mirrors stdlib
+            ``DocTest.globs``. Defaults to ``{'__name__': '__main__'}``.
+        name: human-readable test name; mirrors stdlib ``DocTest.name``.
+        filename: source file path; mirrors stdlib ``DocTest.filename``.
+            Used by xdoctest for failure reporting.
+        lineno: explicit base line number. If ``None``, the first example's
+            ``lineno`` is used so that ``dtest.lineno + part.line_offset``
+            recovers absolute file line numbers.
+        optionflags: stdlib-doctest optionflags ``int`` applying to the whole
+            test. Bits that map to xdoctest builtin flags are translated into
+            runtime state defaults; the rest are kept as checker-only
+            optionflag bits and delivered to the active output checker.
+        config: optional mapping of :class:`DoctestConfig` keys to merge into
+            the resulting ``DocTest.config``. Most useful for setting
+            ``output_checker`` to select a registered checker.
+
+    Returns:
+        DocTest: configured to run via :meth:`DocTest.run`.
+
+    Notes:
+        Per-example ``options`` are attached as structured per-part
+        directives (see module docstring); the source text is never
+        rewritten.
+    """
+    examples = list(examples)
+    if globs is None:
+        globs = {'__name__': '__main__'}
+
+    base, docsrc, example_starts = _build_docsrc(examples)
+    if lineno is None:
+        lineno = base if base is not None else 0
+
+    # Pass filename as ``fpath`` (display path) rather than ``modpath`` so we
+    # don't force a stdlib-style modname lookup against the filesystem; the
+    # input may be a ``.rst`` file or a synthetic name that doesn't resolve
+    # to a Python module.
+    dtest = DocTest(
+        docsrc=docsrc,
+        modpath=None,
+        callname=name,
+        num=0,
+        lineno=lineno,
+        fpath=filename,
+    )
+    dtest.global_namespace = dict(globs)
+
+    # Configure checker selection / persistent checker flags.
+    if config:
+        for key, value in config.items():
+            dtest.config[key] = value
+    if optionflags:
+        # Persistent checker-only optionflag bits flow through
+        # output_checker_flags. Builtin xdoctest flags (ELLIPSIS,
+        # NORMALIZE_WHITESPACE, etc.) are converted into the structured
+        # default_runtime_state via optionflags_to_runtime_state.
+        runstate = directive_facade.optionflags_to_runtime_state(optionflags)
+        defaults: dict = dict(dtest.config.get('default_runtime_state') or {})
+        for key, value in runstate.to_dict().items():
+            if isinstance(value, bool):
+                defaults[key] = value
+        dtest.config['default_runtime_state'] = defaults
+        dtest.config['output_checker_flags'] = int(optionflags)
+
+    _attach_option_directives(dtest, examples, example_starts)
+    return dtest
+
+
+def from_stdlib_doctest(
+    stdlib_test: _doctest.DocTest,
+    *,
+    optionflags: int = 0,
+    config: Optional[Mapping[str, Any]] = None,
+) -> DocTest:
+    """
+    Convenience: convert a stdlib :class:`doctest.DocTest` directly. The
+    metadata (``name``, ``filename``, ``lineno``, ``globs``) is taken from
+    the input.
+    """
+    # In stdlib, ``DocTest.lineno`` is the line of the docstring in the file
+    # and each ``Example.lineno`` is an offset within that docstring. So the
+    # absolute file line of the first example is ``stdlib_test.lineno +
+    # examples[0].lineno``. We pass that sum as the converter base so xdoctest
+    # reports ``dtest.lineno + part.line_offset`` as absolute file line.
+    examples = list(stdlib_test.examples)
+    if examples:
+        absolute_base = (stdlib_test.lineno or 0) + (examples[0].lineno or 0)
+    else:
+        absolute_base = stdlib_test.lineno or 0
+    return from_examples(
+        examples,
+        globs=stdlib_test.globs,
+        name=stdlib_test.name,
+        filename=stdlib_test.filename,
+        lineno=absolute_base,
+        optionflags=optionflags,
+        config=config,
+    )
+
+
+def _build_docsrc(examples):
+    """
+    Reconstruct a ``>>>``-prefixed doctest source string from stdlib-shaped
+    examples, padding with blank lines so each example's prompt line in the
+    reconstructed source mirrors its original ``Example.lineno`` offset.
+
+    Returns ``(base_lineno, docsrc, example_starts)`` where:
+
+    - ``base_lineno`` is the lineno of the first example (the offset that
+      should be passed to :class:`DocTest.lineno` so absolute file lines can
+      be recovered), or ``None`` if no examples were provided.
+    - ``docsrc`` is the reconstructed source.
+    - ``example_starts`` is a list of ``(docsrc_line, example_index)`` pairs
+      recording where each example's source begins in the rebuilt docsrc.
+    """
+    if not examples:
+        return None, '', []
+
+    base = examples[0].lineno
+    lines: list[str] = []
+    example_starts: list[tuple[int, int]] = []
+    cursor = 0
+
+    for idx, ex in enumerate(examples):
+        target = (ex.lineno or 0) - base
+        # Pad blank lines so the prompt aligns with the original lineno.
+        while cursor < target:
+            lines.append('')
+            cursor += 1
+
+        example_starts.append((cursor, idx))
+        src_lines = (ex.source or '').splitlines() or ['']
+        for i, line in enumerate(src_lines):
+            prefix = '>>> ' if i == 0 else '... '
+            lines.append(prefix + line)
+            cursor += 1
+
+        if ex.want:
+            for w in ex.want.splitlines():
+                lines.append(w)
+                cursor += 1
+
+    return base, '\n'.join(lines), example_starts
+
+
+def _attach_option_directives(dtest, examples, example_starts):
+    """
+    Translate per-example ``options`` dicts into structured per-part
+    directives on the parsed :class:`DocTest`.
+
+    xdoctest may merge consecutive want-less examples into one part, so each
+    part collects the options of every example whose source starts within
+    its line span (later examples win on conflicting flags).
+    """
+    if not example_starts:
+        return
+    if not any(getattr(examples[idx], 'options', None) for _, idx in example_starts):
+        return
+
+    dtest._parse()
+    parts = dtest._parts or []
+    if not parts:
+        return
+
+    part_offsets = [part.line_offset for part in parts]
+    examples_by_part: dict[int, list[int]] = {}
+    for start_line, ex_idx in example_starts:
+        partx = bisect.bisect_right(part_offsets, start_line) - 1
+        if partx < 0:
+            continue
+        examples_by_part.setdefault(partx, []).append(ex_idx)
+
+    for partx, ex_idxs in examples_by_part.items():
+        merged: dict = {}
+        for ex_idx in ex_idxs:
+            merged.update(getattr(examples[ex_idx], 'options', None) or {})
+        extra = _options_to_directives(merged)
+        if extra:
+            part = parts[partx]
+            # Preserve directives written inline in the original source;
+            # structured options come after so they win on conflict.
+            part._directives = list(part.directives) + extra
+
+
+def _options_to_directives(options):
+    """
+    Convert a stdlib-style ``{flag_bit: bool}`` options dict into a list of
+    per-part (inline) :class:`~xdoctest.directive.Directive` objects.
+
+    Unnamed bits are silently dropped (they cannot be expressed); named bits
+    unknown to xdoctest are adopted as checker-only optionflags.
+    """
+    if not options:
+        return []
+    names_by_bit = {
+        bit: name for name, bit in _doctest.OPTIONFLAGS_BY_NAME.items()
+    }
+    directives = []
+    for flag, value in options.items():
+        name = names_by_bit.get(flag)
+        if name is None:
+            continue
+        name = name.upper()
+        if (
+            name not in directive.COMMANDS
+            and not directive_facade.is_registered_optionflag(name)
+        ):
+            # Adopt any stdlib-registered flag so the directive system can
+            # carry it through to the output checker as a checker-only bit.
+            directive_facade.register_optionflag(name)
+        directives.append(
+            directive.Directive(name, positive=bool(value), inline=True)
+        )
+    return directives
+
+
+__all__ = [
+    'from_examples',
+    'from_stdlib_doctest',
+]

--- a/tests/test_checker_compat.py
+++ b/tests/test_checker_compat.py
@@ -4,7 +4,7 @@ import doctest
 
 import xdoctest
 from xdoctest import checker, doctest_example, utils
-from xdoctest import directive_facade
+from xdoctest import checker_facade, directive_facade
 
 
 def test_register_optionflag_is_stable() -> None:
@@ -14,12 +14,14 @@ def test_register_optionflag_is_stable() -> None:
 
 
 def test_runtime_state_optionflag_roundtrip_for_builtin_flags() -> None:
-    runstate = xdoctest.optionflags_to_runtime_state(
-        xdoctest.FLOAT_CMP | xdoctest.ELLIPSIS
+    from xdoctest import interop
+
+    runstate = interop.optionflags_to_runtime_state(
+        directive_facade.FLOAT_CMP | directive_facade.ELLIPSIS
     )
-    flags = xdoctest.runtime_state_to_optionflags(runstate)
-    assert flags & xdoctest.FLOAT_CMP
-    assert flags & xdoctest.ELLIPSIS
+    flags = interop.runtime_state_to_optionflags(runstate)
+    assert flags & directive_facade.FLOAT_CMP
+    assert flags & directive_facade.ELLIPSIS
 
 
 FIX = doctest.register_optionflag('FIX')
@@ -129,7 +131,7 @@ def test_resolve_current_checker_honors_mapping_state() -> None:
         pass
 
     xdoctest.register_checker('mapping_checker', MappingChecker)
-    resolved = xdoctest.checker_facade.resolve_current_checker(
+    resolved = checker_facade.resolve_current_checker(
         {'_output_checker': 'mapping_checker'}
     )
     assert isinstance(resolved, MappingChecker)

--- a/tests/test_checker_compat.py
+++ b/tests/test_checker_compat.py
@@ -309,3 +309,43 @@ def test_end_to_end_registered_checker_flag_works_via_directive() -> None:
     self.config['output_checker'] = 'fix_directive_checker'
     result = self.run(verbose=0, on_error='raise')
     assert result['passed']
+
+
+def test_resolve_checker_caches_class_instances() -> None:
+    from xdoctest import checker_facade
+
+    class Counting(doctest.OutputChecker):
+        instances = 0
+
+        def __init__(self):
+            Counting.instances += 1
+
+    checker_facade.register_checker('counting_checker', Counting)
+    first = checker_facade.resolve_checker('counting_checker')
+    second = checker_facade.resolve_checker('counting_checker')
+    assert first is second
+    assert Counting.instances == 1
+
+    # Re-registering invalidates the cached instance.
+    checker_facade.register_checker('counting_checker', Counting)
+    third = checker_facade.resolve_checker('counting_checker')
+    assert third is not first
+    assert Counting.instances == 2
+
+
+def test_native_check_does_not_construct_registered_checkers() -> None:
+    """
+    The default 'xdoctest' path must not pay the facade round-trip: a
+    registered (but unselected) checker class must never be constructed.
+    """
+    from xdoctest import checker_facade
+    from xdoctest import directive
+
+    class Exploding(doctest.OutputChecker):
+        def __init__(self):
+            raise AssertionError('native path must not construct this')
+
+    checker_facade.register_checker('exploding_checker', Exploding)
+    runstate = directive.RuntimeState()
+    assert checker.check_output('1\n', '1\n', runstate)
+    assert not checker.check_output('1\n', '2\n', runstate)

--- a/tests/test_doctest_example.py
+++ b/tests/test_doctest_example.py
@@ -890,3 +890,40 @@ if __name__ == '__main__':
     import xdoctest
 
     xdoctest.doctest_module(__file__)
+
+
+def test_requirement_check_without_packaging(monkeypatch):
+    """
+    Without the optional ``packaging`` dependency, bare-name requirements
+    still work; constrained requirements warn and count as unsatisfied
+    (skip) instead of raising.
+    """
+    import warnings
+    from xdoctest import doctest_example as mod
+
+    monkeypatch.setattr(mod, 'Requirement', None)
+    assert mod._doctest_requirement_satisfied('os')
+    assert not mod._doctest_requirement_satisfied(
+        'definitely_missing_package_123456'
+    )
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        assert not mod._doctest_requirement_satisfied('pytest>=1')
+    assert any('packaging is required' in str(w.message) for w in record)
+
+
+def test_static_module_metadata_is_cached(tmp_path):
+    from xdoctest import doctest_example as mod
+
+    fpath = tmp_path / 'mymod.py'
+    fpath.write_text(
+        '__doctest_skip__ = ["skip_me"]\n'
+        '__doctest_requires__ = {"needs_os": ["os"]}\n'
+    )
+    mod._static_module_doctest_metadata.cache_clear()
+    first = mod._static_module_doctest_metadata(str(fpath))
+    second = mod._static_module_doctest_metadata(str(fpath))
+    assert first == (['skip_me'], {'needs_os': ['os']})
+    assert second is first
+    info = mod._static_module_doctest_metadata.cache_info()
+    assert info.hits == 1

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2230,3 +2230,52 @@ class Disabled:
         items, reprec = testdir.inline_genitems(p, '--xdoctest-modules')
         reportinfo = items[0].reportinfo()
         assert reportinfo[1] == 1
+
+
+class TestDoctestPlusCoexistence:
+    def test_namespace_fixture_fallback(self) -> None:
+        """
+        When an XDoctestItem is embedded without xdoctest's plugin, the
+        xdoctest_namespace fixture is absent and the namespace is empty.
+        """
+        from xdoctest.plugin import (
+            _FixtureLookupError,
+            _lookup_namespace_fixture,
+        )
+
+        err = _FixtureLookupError.__new__(_FixtureLookupError)
+
+        def missing(name):
+            raise err
+
+        assert _lookup_namespace_fixture(missing) == {}
+        assert _lookup_namespace_fixture(lambda name: {'a': 1}) == {'a': 1}
+
+    def test_textfile_collection_defers_to_doctestplus(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        """
+        With pytest-doctestplus enabled, xdoctest must not collect
+        .rst/.txt files: doctestplus' parser owns the RST directive
+        language.
+        """
+        pytest.importorskip('pytest_doctestplus')
+        testdir.maketxtfile(
+            narrative="""
+            A doctestplus-style directive that xdoctest cannot parse:
+
+            .. doctest-skip::
+
+                >>> raise RuntimeError('never runs')
+            """
+        )
+        result = testdir.runpytest(
+            'narrative.txt',
+            '--doctest-plus',
+            '--collect-only',
+            '-q',
+            '-p', 'pytest_doctestplus',
+            '-p', 'no:doctest',
+            '--xdoctest-nocolor',
+        )
+        result.stdout.no_fnmatch_line('*XDoctestTextfile*')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1576,6 +1576,39 @@ class TestXDoctestModuleMetadata:
         reprec = testdir.inline_run('--xdoctest-modules', *EXTRA_ARGS)
         reprec.assertoutcome(passed=1, skipped=2)
 
+    def test_metadata_skip_reason_is_reported(
+        self, testdir: pytest.Testdir
+    ) -> None:
+        testdir.makepyfile(
+            meta=utils.codeblock(
+                """
+                __doctest_skip__ = ['skip_me']
+                __doctest_requires__ = {
+                    'needs_missing': ['definitely_missing_package_123456'],
+                }
+
+                def skip_me():
+                    '''
+                    >>> 1
+                    2
+                    '''
+
+                def needs_missing():
+                    '''
+                    >>> 1
+                    1
+                    '''
+                """
+            )
+        )
+        result = testdir.runpytest(
+            '--xdoctest-modules', '-rs', *EXTRA_ARGS
+        )
+        result.stdout.fnmatch_lines(['*listed in `__doctest_skip__`*'])
+        result.stdout.fnmatch_lines(
+            ['*unmet `__doctest_requires__` requirement*']
+        )
+
     def test_doctestplus_requires_metadata(
         self, testdir: pytest.Testdir
     ) -> None:

--- a/tests/test_stdlib_compat.py
+++ b/tests/test_stdlib_compat.py
@@ -65,6 +65,30 @@ def test_skip_option_is_honored():
     assert result['passed']
 
 
+def test_per_example_skip_preserves_execution_boundary():
+    """A skipped want-less example must not skip adjacent setup code."""
+    examples = [
+        doctest.Example(source='x = 1\n', want='', lineno=0),
+        doctest.Example(
+            source='raise RuntimeError("should not run")\n',
+            want='',
+            lineno=1,
+            options={doctest.SKIP: True},
+        ),
+        doctest.Example(source='print(x)\n', want='1\n', lineno=2),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed'], result
+    assert not result['failed']
+    assert dtest._parts is not None
+    assert [part.source for part in dtest._parts] == [
+        'x = 1',
+        'raise RuntimeError("should not run")',
+        'print(x)',
+    ]
+
+
 def test_skip_option_does_not_rewrite_source():
     """
     SKIP is attached as a structured per-part directive; the reconstructed

--- a/tests/test_stdlib_compat.py
+++ b/tests/test_stdlib_compat.py
@@ -1,0 +1,181 @@
+"""Tests for the stdlib-doctest intake seam."""
+
+from __future__ import annotations
+
+import doctest
+
+import pytest
+
+import xdoctest
+from xdoctest import stdlib_compat
+
+
+def test_synthetic_example_runs_successfully():
+    examples = [doctest.Example(source='print(1)\n', want='1\n', lineno=0)]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed']
+    assert not result['failed']
+
+
+def test_synthetic_example_with_failure_reports_correct_line():
+    # Example at line 4 in the source file. Expecting 1, returns 2.
+    examples = [doctest.Example(source='print(2)\n', want='1\n', lineno=4)]
+    dtest = stdlib_compat.from_examples(
+        examples, name='t', filename='/tmp/fake.py'
+    )
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['failed']
+    # dtest.lineno should align with the first example's lineno so that
+    # absolute file line is recovered as dtest.lineno + part.line_offset.
+    assert dtest.lineno == 4
+    assert dtest.failed_part is not None
+    assert not isinstance(dtest.failed_part, str)
+    assert dtest.failed_part.line_offset == 0
+
+
+def test_multiple_examples_preserve_lineno_spacing():
+    examples = [
+        doctest.Example(source='x = 1\n', want='', lineno=10),
+        doctest.Example(source='print(x)\n', want='1\n', lineno=20),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    assert dtest.lineno == 10
+    # Force a parse to populate _parts so we can inspect line offsets.
+    dtest._parse()
+    parts = dtest._parts
+    assert parts is not None and len(parts) >= 2
+    # Second example should be at offset 10 from the start of the docsrc,
+    # so its absolute line resolves to dtest.lineno + 10 == 20.
+    assert parts[-1].line_offset == 10
+
+
+def test_skip_option_is_honored():
+    examples = [
+        doctest.Example(
+            source='raise RuntimeError("should not run")\n',
+            want='',
+            lineno=0,
+            options={doctest.SKIP: True},
+        ),
+        doctest.Example(source='print(2)\n', want='2\n', lineno=2),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='raise')
+    assert result['passed']
+
+
+def test_skip_option_does_not_rewrite_source():
+    """
+    SKIP is attached as a structured per-part directive; the reconstructed
+    source must stay byte-identical to what the user wrote.
+    """
+    examples = [
+        doctest.Example(
+            source='raise RuntimeError("should not run")\n',
+            want='',
+            lineno=0,
+            options={doctest.SKIP: True},
+        ),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    assert dtest.docsrc is not None
+    assert 'xdoctest' not in dtest.docsrc
+    assert 'SKIP' not in dtest.docsrc
+
+
+def test_per_example_option_applies_to_matching_part_only():
+    """
+    A checker-only flag set on one example must reach the checker for that
+    part but not for other parts.
+    """
+    part_flag = xdoctest.register_optionflag('PART_LOCAL_INTAKE')
+
+    seen: list[int] = []
+
+    class Recorder(doctest.OutputChecker):
+        def check_output(self, want, got, optionflags):
+            seen.append(optionflags)
+            return xdoctest.OutputChecker().check_output(want, got, optionflags)
+
+    xdoctest.register_checker('part_local_recorder', Recorder)
+
+    examples = [
+        doctest.Example(
+            source='print(1)\n',
+            want='1\n',
+            lineno=0,
+            options={part_flag: True},
+        ),
+        doctest.Example(source='print(2)\n', want='2\n', lineno=2),
+    ]
+    dtest = stdlib_compat.from_examples(
+        examples,
+        name='t',
+        config={'output_checker': 'part_local_recorder'},
+    )
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed']
+    assert len(seen) >= 2
+    assert seen[0] & part_flag
+    assert not (seen[-1] & part_flag)
+
+
+def test_registered_checker_only_flag_flows_through():
+    fix_flag = xdoctest.register_optionflag('FIX_INTAKE')
+
+    seen: list[int] = []
+
+    class Recorder(doctest.OutputChecker):
+        def check_output(self, want, got, optionflags):
+            seen.append(optionflags)
+            return xdoctest.OutputChecker().check_output(want, got, optionflags)
+
+    xdoctest.register_checker('intake_recorder', Recorder)
+
+    examples = [doctest.Example(source='print(1)\n', want='1\n', lineno=0)]
+    dtest = stdlib_compat.from_examples(
+        examples,
+        name='t',
+        optionflags=fix_flag,
+        config={'output_checker': 'intake_recorder'},
+    )
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed']
+    assert seen
+    assert seen[-1] & fix_flag
+
+
+def test_stdlib_doctest_roundtrip_runs():
+    stdlib_ex = doctest.Example(source='print("hi")\n', want='hi\n', lineno=2)
+    stdlib_test = doctest.DocTest(
+        examples=[stdlib_ex],
+        globs={'__name__': '__main__'},
+        name='m.f',
+        filename='/tmp/m.py',
+        lineno=10,
+        docstring='',
+    )
+    dtest = stdlib_compat.from_stdlib_doctest(stdlib_test)
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed']
+    # Stdlib's docstring lineno (10) plus first-example offset (2) gives
+    # the absolute file line. The converter sets dtest.lineno to that sum
+    # so xdoctest's "dtest.lineno + part.line_offset" recovers it.
+    assert dtest.lineno == 12
+
+
+def test_builtin_optionflag_translates_to_runtime_state():
+    # ELLIPSIS is a builtin xdoctest flag; the want uses ... to match anything.
+    examples = [
+        doctest.Example(
+            source='print("anything happens here")\n',
+            want='anything ...\n',
+            lineno=0,
+        )
+    ]
+    dtest = stdlib_compat.from_examples(
+        examples, name='t', optionflags=doctest.ELLIPSIS
+    )
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed'], result

--- a/tests/test_stdlib_compat_warnings.py
+++ b/tests/test_stdlib_compat_warnings.py
@@ -1,0 +1,154 @@
+"""
+Tests for runner-level warning policy on the stdlib-doctest intake seam.
+"""
+
+from __future__ import annotations
+
+import doctest
+
+import pytest
+
+import xdoctest
+from xdoctest import stdlib_compat
+
+
+def _register_warning_flags():
+    """
+    Ensure both IGNORE_WARNINGS and SHOW_WARNINGS optionflag names exist
+    in the registry. Either stdlib doctest or doctestplus might register
+    them first; we just want stable ints in this test.
+    """
+    return (
+        doctest.register_optionflag('IGNORE_WARNINGS'),
+        doctest.register_optionflag('SHOW_WARNINGS'),
+    )
+
+
+def test_warning_policy_does_not_rewrite_source():
+    """
+    The user code source must be preserved verbatim; the runner-level
+    policy must not wrap it in a context manager (which would shift line
+    numbers and obscure failure tracebacks).
+    """
+    ignore_flag, _ = _register_warning_flags()
+    user_source = 'import warnings; warnings.warn("noisy")\n'
+    examples = [
+        doctest.Example(
+            source=user_source,
+            want='',
+            lineno=0,
+            options={ignore_flag: True},
+        )
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    assert dtest.docsrc is not None
+    assert user_source.strip() in dtest.docsrc
+    # Source should not contain the doctestplus wrapper class.
+    assert '_doctestplus_ignore_all_warnings' not in dtest.docsrc
+    # And not a generic catch_warnings wrapper either.
+    assert 'catch_warnings' not in dtest.docsrc
+
+
+def test_ignore_warnings_silences_warning():
+    ignore_flag, _ = _register_warning_flags()
+    examples = [
+        doctest.Example(
+            source='import warnings; warnings.warn("nope")\n',
+            want='',
+            lineno=0,
+            options={ignore_flag: True},
+        )
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as record:
+        _warnings.simplefilter('always')
+        result = dtest.run(verbose=0, on_error='return')
+    assert result['passed'], result
+    # The warning emitted inside the doctest must not escape past the
+    # per-part context manager.
+    user_warnings = [w for w in record if 'nope' in str(w.message)]
+    assert not user_warnings
+
+
+def test_show_warnings_captures_via_stdout():
+    _, show_flag = _register_warning_flags()
+    examples = [
+        doctest.Example(
+            source='import warnings; warnings.warn("hello")\n',
+            want='UserWarning: hello\n',
+            lineno=0,
+            options={show_flag: True},
+        )
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed'], result
+
+
+def test_failure_inside_warning_context_points_at_user_code_line():
+    """
+    Even when a warning context wraps execution, a failure inside the user
+    code must report the original file line — not a wrapper line.
+    """
+    ignore_flag, _ = _register_warning_flags()
+    # Example originally at file line 7; expected output mismatch.
+    examples = [
+        doctest.Example(
+            source='import warnings; print(2)\n',
+            want='1\n',
+            lineno=7,
+            options={ignore_flag: True},
+        )
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['failed']
+    assert dtest.lineno == 7
+    assert dtest.failed_part is not None
+    assert not isinstance(dtest.failed_part, str)
+    # Ensure the failed part begins at offset 0 of docsrc -> absolute line 7.
+    assert dtest.failed_part.line_offset == 0
+
+
+def test_no_warning_policy_uses_default_no_op_context():
+    examples = [
+        doctest.Example(source='print(1)\n', want='1\n', lineno=0),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    # Without an active runstate (or warning flags) _part_context is a no-op.
+    from contextlib import nullcontext
+
+    cm = dtest._part_context(None, 0)
+    assert isinstance(cm, type(nullcontext()))
+
+
+def test_warning_policy_is_per_part():
+    """
+    Warning flags on one example must not leak into other examples: the
+    second part emits a warning without any flag, so it must escape to the
+    ambient recorder while the first part's warning is silenced.
+    """
+    ignore_flag, _ = _register_warning_flags()
+    examples = [
+        doctest.Example(
+            source='import warnings; warnings.warn("quiet")\n',
+            want='',
+            lineno=0,
+            options={ignore_flag: True},
+        ),
+        doctest.Example(
+            source='import warnings; warnings.warn("loud")\n',
+            want='',
+            lineno=2,
+            options={},
+        ),
+    ]
+    dtest = stdlib_compat.from_examples(examples, name='t')
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['passed'], result
+    # The runner records warnings that escape the parts in dtest.warn_list.
+    messages = [str(w.message) for w in (dtest.warn_list or [])]
+    assert not any('quiet' in m for m in messages)
+    assert any('loud' in m for m in messages)

--- a/tests/test_warning_directives.py
+++ b/tests/test_warning_directives.py
@@ -1,0 +1,132 @@
+"""
+Tests for the native IGNORE_WARNINGS / SHOW_WARNINGS runtime directives.
+
+These directives apply warning policy at the runner level: the part's source
+is never rewritten, so failure line numbers always point at user code.
+"""
+
+from xdoctest import doctest_example, utils
+
+
+def _run(docsrc):
+    dtest = doctest_example.DocTest(docsrc=docsrc)
+    return dtest, dtest.run(on_error='return', verbose=0)
+
+
+def test_ignore_warnings_inline():
+    """
+    An inline +IGNORE_WARNINGS silences a warning that would otherwise be
+    escalated to an error by the ambient filter.
+    """
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.simplefilter('error')
+        >>> warnings.warn('boo')  # xdoctest: +IGNORE_WARNINGS
+        >>> print('done')
+        done
+        """
+    )
+    dtest, result = _run(string)
+    assert result['passed']
+
+
+def test_escalated_warning_fails_without_directive():
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.simplefilter('error')
+        >>> warnings.warn('boo')
+        >>> print('done')
+        done
+        """
+    )
+    dtest, result = _run(string)
+    assert result['failed']
+
+
+def test_show_warnings_inline():
+    """
+    +SHOW_WARNINGS prints captured warnings as ``Category: message`` lines
+    that participate in got/want matching.
+    """
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.warn('boo')  # xdoctest: +SHOW_WARNINGS
+        UserWarning: boo
+        """
+    )
+    dtest, result = _run(string)
+    assert result['passed']
+
+
+def test_warning_not_shown_without_directive():
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.warn('boo')
+        UserWarning: boo
+        """
+    )
+    dtest, result = _run(string)
+    assert result['failed']
+
+
+def test_ignore_warnings_block_scope():
+    """
+    A block-form directive persists for subsequent parts until disabled.
+    """
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.simplefilter('error')
+        >>> print('setup')
+        setup
+        >>> # xdoctest: +IGNORE_WARNINGS
+        >>> warnings.warn('one')
+        >>> print('a')
+        a
+        >>> warnings.warn('two')
+        >>> print('b')
+        b
+        """
+    )
+    dtest, result = _run(string)
+    assert result['passed']
+
+
+def test_ignore_takes_precedence_over_show():
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> # xdoctest: +IGNORE_WARNINGS, +SHOW_WARNINGS
+        >>> warnings.warn('boo')
+        >>> print('done')
+        done
+        """
+    )
+    dtest, result = _run(string)
+    assert result['passed']
+
+
+def test_show_warnings_preserves_source_and_lineno():
+    """
+    A failing part under SHOW_WARNINGS reports the original user source, not
+    wrapper code, and the failing part's line offset matches the user line.
+    """
+    string = utils.codeblock(
+        """
+        >>> import warnings
+        >>> warnings.warn('boo')  # xdoctest: +SHOW_WARNINGS
+        UserWarning: not-what-was-warned
+        """
+    )
+    dtest, result = _run(string)
+    assert result['failed']
+    failed_part = dtest.failed_part
+    assert 'with ' not in failed_part.source
+    assert "warnings.warn('boo')" in failed_part.source
+    # Got/want failures point at the want line: the part starts at offset 1
+    # and its single want line is at offset 2.
+    assert dtest.failed_line_offset() == 2


### PR DESCRIPTION
## What changed

Each incoming stdlib `doctest.Example` now remains a distinct execution and option boundary, even when xdoctest would normally combine adjacent want-less statements into one part.

## Root cause

Merging options at part granularity allowed a later example's `SKIP` or checker flag to affect neighboring examples.

## Validation

- 16 focused stdlib-intake tests passed, including a red-before regression for leaked `SKIP` scope.
