### PR TITLE
Separate runtime-bound and checker-only option flags

### DIFF
--- a/src/xdoctest/directive_facade.py
+++ b/src/xdoctest/directive_facade.py
@@ -111,6 +111,13 @@ class RuntimeFlagFacade:
     def get_registered_optionflags(self) -> Dict[str, int]:
         return dict(self._optionflags_by_name)
 
+    def _runtime_bound_optionflag_mask(self) -> int:
+        """Return the mask represented by structured runtime-state keys."""
+        mask = 0
+        for flag in self._optionflag_to_runtime_key:
+            mask |= flag
+        return mask
+
     def runtime_state_to_optionflags(
         self,
         runstate: directive.RuntimeState | dict | None,
@@ -125,18 +132,19 @@ class RuntimeFlagFacade:
           :meth:`RuntimeState.get_output_checker_flags`
         - Any builtin flags whose mapped runtime key is currently ``True``
         """
+        runtime_bound_mask = self._runtime_bound_optionflag_mask()
         flags = 0
         if isinstance(runstate, directive.RuntimeState):
-            flags |= runstate.get_output_checker_flags()
+            flags |= runstate.get_output_checker_flags() & ~runtime_bound_mask
             lookup = runstate.__getitem__
         elif runstate is None:
             runstate = directive.RuntimeState()
-            flags |= runstate.get_output_checker_flags()
+            flags |= runstate.get_output_checker_flags() & ~runtime_bound_mask
             lookup = runstate.__getitem__
         else:
             lookup = runstate.__getitem__
             if isinstance(runstate, dict):
-                flags |= int(runstate.get('_optionflags', 0))
+                flags |= int(runstate.get('_optionflags', 0)) & ~runtime_bound_mask
 
         for runtime_key, flag in self._runtime_key_to_optionflag.items():
             try:
@@ -168,7 +176,9 @@ class RuntimeFlagFacade:
         runstate = directive.RuntimeState(
             cast(directive.RuntimeStateDict, base_state)
         )
-        runstate.set_output_checker_flags(optionflags)
+        runtime_bound_mask = self._runtime_bound_optionflag_mask()
+        checker_only_flags = optionflags & ~runtime_bound_mask
+        runstate.set_output_checker_flags(checker_only_flags)
         for flag, runtime_key in self._optionflag_to_runtime_key.items():
             value = runstate[runtime_key]
             if isinstance(value, bool) and (optionflags & flag):

--- a/src/xdoctest/stdlib_compat.py
+++ b/src/xdoctest/stdlib_compat.py
@@ -122,7 +122,9 @@ def from_examples(
             if isinstance(value, bool):
                 defaults[key] = value
         dtest.config['default_runtime_state'] = defaults
-        dtest.config['output_checker_flags'] = int(optionflags)
+        dtest.config['output_checker_flags'] = (
+            runstate.get_output_checker_flags()
+        )
 
     _parse_examples_as_parts(dtest, examples, base)
     return dtest

--- a/tests/test_checker_compat.py
+++ b/tests/test_checker_compat.py
@@ -24,6 +24,23 @@ def test_runtime_state_optionflag_roundtrip_for_builtin_flags() -> None:
     assert flags & directive_facade.ELLIPSIS
 
 
+def test_runtime_bound_flags_follow_current_runtime_state() -> None:
+    from xdoctest import directive, interop
+
+    checker_only = xdoctest.register_optionflag('CHECKER_ONLY_PARTITION')
+    runstate = interop.optionflags_to_runtime_state(
+        checker_only | directive_facade.ELLIPSIS
+    )
+
+    assert runstate['ELLIPSIS']
+    assert runstate.get_output_checker_flags() == checker_only
+
+    runstate.update([directive.Directive('ELLIPSIS', positive=False, inline=True)])
+    flags = interop.runtime_state_to_optionflags(runstate)
+    assert flags & checker_only
+    assert not (flags & directive_facade.ELLIPSIS)
+
+
 FIX = doctest.register_optionflag('FIX')
 
 

--- a/tests/test_stdlib_compat.py
+++ b/tests/test_stdlib_compat.py
@@ -203,3 +203,33 @@ def test_builtin_optionflag_translates_to_runtime_state():
     )
     result = dtest.run(verbose=0, on_error='return')
     assert result['passed'], result
+
+
+def test_local_builtin_option_overrides_global_for_foreign_checker():
+    """A local negative builtin option must clear the foreign-checker bit."""
+    seen: list[int] = []
+
+    class StdlibRecorder(doctest.OutputChecker):
+        def check_output(self, want, got, optionflags):
+            seen.append(optionflags)
+            return super().check_output(want, got, optionflags)
+
+    xdoctest.register_checker('stdlib_override_recorder', StdlibRecorder)
+    examples = [
+        doctest.Example(
+            source='print("prefix suffix")\n',
+            want='prefix ...\n',
+            lineno=0,
+            options={doctest.ELLIPSIS: False},
+        )
+    ]
+    dtest = stdlib_compat.from_examples(
+        examples,
+        name='t',
+        optionflags=doctest.ELLIPSIS,
+        config={'output_checker': 'stdlib_override_recorder'},
+    )
+    result = dtest.run(verbose=0, on_error='return')
+    assert result['failed']
+    assert seen
+    assert not (seen[-1] & doctest.ELLIPSIS)


### PR DESCRIPTION
## What changed

- Separates runtime-bound option bits from checker-only bits.
- Reconstructs the final foreign-checker bitmask from current runtime state.
- Preserves custom checker flags while allowing local negative directives to override global builtin flags.

## Root cause

The original global bitmask retained runtime-bound bits such as `ELLIPSIS`, so a local `-ELLIPSIS` could be ignored by a foreign checker.

## Validation

- 27 focused checker and conversion tests passed.
- The final stack passes 92 focused tests, `ty`, and `mypy`.
